### PR TITLE
chore(travis): let travis compile TypeScript to JavaScript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ cache:
     - "node_modules"
 
 script:
+  - npm run compile
   - npm run lint
   - npm run test


### PR DESCRIPTION
This commit lets Travis compile the TypeScript code to JavaScript from now on.

Because our tests don't cover every file `ts-node` is not compiling all of the TypeScript code which could result in code that can't be compiled getting merged in.