### PR TITLE
Fix Websocket connection TLS #43

### DIFF
--- a/bin/wallid
+++ b/bin/wallid
@@ -10,6 +10,9 @@ const { argv } = require('yargs')
     btcdconfig: {
       type: 'string',
     },
+    btcdcert: {
+      type: 'string',
+    },
     logfile: {
       describe: 'Path to the logfile',
       type: 'string',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -12,6 +12,7 @@ import { errors } from './consts/errors';
 
 type SerivceConfigOption = {
   configPath: string;
+  certPath: string;
 };
 
 type ConfigType = {
@@ -52,6 +53,7 @@ class Config {
         user: '',
         password: '',
         configPath: path.join(this.btcdDir, 'btcd.conf'),
+        certPath: path.join(this.btcdDir, 'rpc.cert'),
       },
       lnd: {
         host: '127.0.0.1',

--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -12,7 +12,6 @@ import { errors } from './consts/errors';
 
 type SerivceConfigOption = {
   configPath: string;
-  certPath: string;
 };
 
 type ConfigType = {

--- a/lib/RpcClient.ts
+++ b/lib/RpcClient.ts
@@ -1,4 +1,5 @@
 import WebSocket from 'ws';
+import fs from 'fs';
 import uuidv1 from 'uuid/v1';
 import { EventEmitter } from 'events';
 
@@ -8,6 +9,7 @@ type RpcConfig = {
   port: number;
   user: string;
   password: string;
+  certPath: string;
 };
 
 /** A hack to make promises handleable from other functions */
@@ -34,11 +36,14 @@ class RpcClient extends EventEmitter {
 
   public connect = async () => {
     return new Promise((resolve, reject) => {
+      const rpccert = fs.readFileSync(this.config.certPath,  { encoding: 'utf-8' });
       const credentials = Buffer.from(`${this.config.user}:${this.config.password}`);
-      this.ws = new WebSocket(`ws://${this.config.host}:${this.config.port}/ws`, {
+      this.ws = new WebSocket(`wss://${this.config.host}:${this.config.port}/ws`, {
         headers: {
           Authorization: `Basic ${credentials.toString('base64')}`,
         },
+        cert: rpccert,
+        ca: [rpccert],
       });
 
       this.ws.onopen = () => {

--- a/lib/RpcClient.ts
+++ b/lib/RpcClient.ts
@@ -36,14 +36,14 @@ class RpcClient extends EventEmitter {
 
   public connect = async () => {
     return new Promise((resolve, reject) => {
-      const rpccert = fs.readFileSync(this.config.certPath,  { encoding: 'utf-8' });
+      const rpcCert = fs.readFileSync(this.config.certPath,  { encoding: 'utf-8' });
       const credentials = Buffer.from(`${this.config.user}:${this.config.password}`);
       this.ws = new WebSocket(`wss://${this.config.host}:${this.config.port}/ws`, {
         headers: {
           Authorization: `Basic ${credentials.toString('base64')}`,
         },
-        cert: rpccert,
-        ca: [rpccert],
+        cert: rpcCert,
+        ca: [rpcCert],
       });
 
       this.ws.onopen = () => {

--- a/lib/RpcClient.ts
+++ b/lib/RpcClient.ts
@@ -34,7 +34,7 @@ class RpcClient extends EventEmitter {
 
   public connect = async () => {
     return new Promise((resolve, reject) => {
-      const credentials = new Buffer(`${this.config.user}:${this.config.password}`);
+      const credentials = Buffer.from(`${this.config.user}:${this.config.password}`);
       this.ws = new WebSocket(`ws://${this.config.host}:${this.config.port}/ws`, {
         headers: {
           Authorization: `Basic ${credentials.toString('base64')}`,

--- a/lib/Walli.ts
+++ b/lib/Walli.ts
@@ -12,13 +12,13 @@ class Walli {
   private logger: Logger;
   private grpcServer: GrpcServer;
   private btcdClient: BtcdClient;
-  private lndClient: LndClient;
+  // private lndClient: LndClient;
 
   constructor(config: Arguments) {
     this.config = new Config().load(config);
     this.logger = new Logger(this.config.logPath, this.config.logLevel);
     this.btcdClient = new BtcdClient(this.logger, this.config.btcd);
-    this.lndClient = new LndClient(this.logger, this.config.lnd);
+    // this.lndClient = new LndClient(this.logger, this.config.lnd);
     this.service = new Service(this.logger, this.btcdClient);
     this.grpcServer = new GrpcServer(this.logger, this.service, this.config.grpc);
   }
@@ -26,7 +26,7 @@ class Walli {
   public start = async () => {
     const connectPromises = [
       this.connectBtcd(),
-      this.connectLnd(),
+      // this.connectLnd(),
       this.startGrpcServer(),
     ];
 
@@ -52,7 +52,7 @@ class Walli {
       this.logger.error(error);
     }
   }
-
+/*
   private connectLnd = async () => {
     try {
       await this.lndClient.connect();
@@ -66,7 +66,7 @@ class Walli {
       this.logCouldNotConnect(LndClient.serviceName, error);
     }
   }
-
+*/
   private logCouldNotConnect = (service: string, error: any) => {
     this.logger.error(`could not connect to ${service}: ${JSON.stringify(error)}`);
   }

--- a/lib/Walli.ts
+++ b/lib/Walli.ts
@@ -12,13 +12,13 @@ class Walli {
   private logger: Logger;
   private grpcServer: GrpcServer;
   private btcdClient: BtcdClient;
-  // private lndClient: LndClient;
+  private lndClient: LndClient;
 
   constructor(config: Arguments) {
     this.config = new Config().load(config);
     this.logger = new Logger(this.config.logPath, this.config.logLevel);
     this.btcdClient = new BtcdClient(this.logger, this.config.btcd);
-    // this.lndClient = new LndClient(this.logger, this.config.lnd);
+    this.lndClient = new LndClient(this.logger, this.config.lnd);
     this.service = new Service(this.logger, this.btcdClient);
     this.grpcServer = new GrpcServer(this.logger, this.service, this.config.grpc);
   }
@@ -26,7 +26,7 @@ class Walli {
   public start = async () => {
     const connectPromises = [
       this.connectBtcd(),
-      // this.connectLnd(),
+      this.connectLnd(),
       this.startGrpcServer(),
     ];
 
@@ -52,7 +52,7 @@ class Walli {
       this.logger.error(error);
     }
   }
-/*
+
   private connectLnd = async () => {
     try {
       await this.lndClient.connect();
@@ -66,7 +66,7 @@ class Walli {
       this.logCouldNotConnect(LndClient.serviceName, error);
     }
   }
-*/
+
   private logCouldNotConnect = (service: string, error: any) => {
     this.logger.error(`could not connect to ${service}: ${JSON.stringify(error)}`);
   }

--- a/lib/chain/BtcdClient.ts
+++ b/lib/chain/BtcdClient.ts
@@ -33,7 +33,6 @@ class BtcdClient extends BaseClientClass implements ChainClient, BtcdClient {
 
   constructor(logger: Logger, config: RpcConfig) {
     super(logger, BtcdClient.serviceName);
-
     this.rpcClient = new RpcClient(config);
     this.rpcClient.on('error', error => this.emit('error', error));
   }

--- a/lib/proto/google/api/annotations_pb.d.ts
+++ b/lib/proto/google/api/annotations_pb.d.ts
@@ -1,10 +1,9 @@
 // package: google.api
 // file: google/api/annotations.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 import * as google_api_http_pb from "../../google/api/http_pb";
 import * as google_protobuf_descriptor_pb from "google-protobuf/google/protobuf/descriptor_pb";
 
-export const http: jspb.ExtensionFieldInfo<google_api_http_pb.HttpRule>;
+  export const http: jspb.ExtensionFieldInfo<google_api_http_pb.HttpRule>;
+

--- a/lib/proto/google/api/http_pb.d.ts
+++ b/lib/proto/google/api/http_pb.d.ts
@@ -1,147 +1,128 @@
 // package: google.api
 // file: google/api/http.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 
-export class Http extends jspb.Message { 
-    clearRulesList(): void;
-    getRulesList(): Array<HttpRule>;
-    setRulesList(value: Array<HttpRule>): void;
-    addRules(value?: HttpRule, index?: number): HttpRule;
+export class Http extends jspb.Message {
+  clearRulesList(): void;
+  getRulesList(): Array<HttpRule>;
+  setRulesList(value: Array<HttpRule>): void;
+  addRules(value?: HttpRule, index?: number): HttpRule;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Http.AsObject;
-    static toObject(includeInstance: boolean, msg: Http): Http.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Http, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Http;
-    static deserializeBinaryFromReader(message: Http, reader: jspb.BinaryReader): Http;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Http.AsObject;
+  static toObject(includeInstance: boolean, msg: Http): Http.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Http, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Http;
+  static deserializeBinaryFromReader(message: Http, reader: jspb.BinaryReader): Http;
 }
 
 export namespace Http {
-    export type AsObject = {
-        rulesList: Array<HttpRule.AsObject>,
-    }
+  export type AsObject = {
+    rulesList: Array<HttpRule.AsObject>,
+  }
 }
 
-export class HttpRule extends jspb.Message { 
-    getSelector(): string;
-    setSelector(value: string): void;
+export class HttpRule extends jspb.Message {
+  getSelector(): string;
+  setSelector(value: string): void;
 
+  hasGet(): boolean;
+  clearGet(): void;
+  getGet(): string;
+  setGet(value: string): void;
 
-    hasGet(): boolean;
-    clearGet(): void;
-    getGet(): string;
-    setGet(value: string): void;
+  hasPut(): boolean;
+  clearPut(): void;
+  getPut(): string;
+  setPut(value: string): void;
 
+  hasPost(): boolean;
+  clearPost(): void;
+  getPost(): string;
+  setPost(value: string): void;
 
-    hasPut(): boolean;
-    clearPut(): void;
-    getPut(): string;
-    setPut(value: string): void;
+  hasDelete(): boolean;
+  clearDelete(): void;
+  getDelete(): string;
+  setDelete(value: string): void;
 
+  hasPatch(): boolean;
+  clearPatch(): void;
+  getPatch(): string;
+  setPatch(value: string): void;
 
-    hasPost(): boolean;
-    clearPost(): void;
-    getPost(): string;
-    setPost(value: string): void;
+  hasCustom(): boolean;
+  clearCustom(): void;
+  getCustom(): CustomHttpPattern | undefined;
+  setCustom(value?: CustomHttpPattern): void;
 
+  getBody(): string;
+  setBody(value: string): void;
 
-    hasDelete(): boolean;
-    clearDelete(): void;
-    getDelete(): string;
-    setDelete(value: string): void;
+  clearAdditionalBindingsList(): void;
+  getAdditionalBindingsList(): Array<HttpRule>;
+  setAdditionalBindingsList(value: Array<HttpRule>): void;
+  addAdditionalBindings(value?: HttpRule, index?: number): HttpRule;
 
-
-    hasPatch(): boolean;
-    clearPatch(): void;
-    getPatch(): string;
-    setPatch(value: string): void;
-
-
-    hasCustom(): boolean;
-    clearCustom(): void;
-    getCustom(): CustomHttpPattern | undefined;
-    setCustom(value?: CustomHttpPattern): void;
-
-    getBody(): string;
-    setBody(value: string): void;
-
-    clearAdditionalBindingsList(): void;
-    getAdditionalBindingsList(): Array<HttpRule>;
-    setAdditionalBindingsList(value: Array<HttpRule>): void;
-    addAdditionalBindings(value?: HttpRule, index?: number): HttpRule;
-
-
-    getPatternCase(): HttpRule.PatternCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): HttpRule.AsObject;
-    static toObject(includeInstance: boolean, msg: HttpRule): HttpRule.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: HttpRule, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): HttpRule;
-    static deserializeBinaryFromReader(message: HttpRule, reader: jspb.BinaryReader): HttpRule;
+  getPatternCase(): HttpRule.PatternCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): HttpRule.AsObject;
+  static toObject(includeInstance: boolean, msg: HttpRule): HttpRule.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: HttpRule, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): HttpRule;
+  static deserializeBinaryFromReader(message: HttpRule, reader: jspb.BinaryReader): HttpRule;
 }
 
 export namespace HttpRule {
-    export type AsObject = {
-        selector: string,
-        get: string,
-        put: string,
-        post: string,
-        pb_delete: string,
-        patch: string,
-        custom?: CustomHttpPattern.AsObject,
-        body: string,
-        additionalBindingsList: Array<HttpRule.AsObject>,
-    }
+  export type AsObject = {
+    selector: string,
+    get: string,
+    put: string,
+    post: string,
+    pb_delete: string,
+    patch: string,
+    custom?: CustomHttpPattern.AsObject,
+    body: string,
+    additionalBindingsList: Array<HttpRule.AsObject>,
+  }
 
-    export enum PatternCase {
-        PATTERN_NOT_SET = 0,
-    
+  export enum PatternCase {
+    PATTERN_NOT_SET = 0,
     GET = 2,
-
     PUT = 3,
-
     POST = 4,
-
     DELETE = 5,
-
     PATCH = 6,
-
     CUSTOM = 8,
-
-    }
-
+  }
 }
 
-export class CustomHttpPattern extends jspb.Message { 
-    getKind(): string;
-    setKind(value: string): void;
+export class CustomHttpPattern extends jspb.Message {
+  getKind(): string;
+  setKind(value: string): void;
 
-    getPath(): string;
-    setPath(value: string): void;
+  getPath(): string;
+  setPath(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): CustomHttpPattern.AsObject;
-    static toObject(includeInstance: boolean, msg: CustomHttpPattern): CustomHttpPattern.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: CustomHttpPattern, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): CustomHttpPattern;
-    static deserializeBinaryFromReader(message: CustomHttpPattern, reader: jspb.BinaryReader): CustomHttpPattern;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): CustomHttpPattern.AsObject;
+  static toObject(includeInstance: boolean, msg: CustomHttpPattern): CustomHttpPattern.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CustomHttpPattern, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CustomHttpPattern;
+  static deserializeBinaryFromReader(message: CustomHttpPattern, reader: jspb.BinaryReader): CustomHttpPattern;
 }
 
 export namespace CustomHttpPattern {
-    export type AsObject = {
-        kind: string,
-        path: string,
-    }
+  export type AsObject = {
+    kind: string,
+    path: string,
+  }
 }
+

--- a/lib/proto/google/protobuf/descriptor_pb.d.ts
+++ b/lib/proto/google/protobuf/descriptor_pb.d.ts
@@ -1,357 +1,326 @@
 // package: google.protobuf
 // file: google/protobuf/descriptor.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
 
-export class FileDescriptorSet extends jspb.Message { 
-    clearFileList(): void;
-    getFileList(): Array<FileDescriptorProto>;
-    setFileList(value: Array<FileDescriptorProto>): void;
-    addFile(value?: FileDescriptorProto, index?: number): FileDescriptorProto;
+export class FileDescriptorSet extends jspb.Message {
+  clearFileList(): void;
+  getFileList(): Array<FileDescriptorProto>;
+  setFileList(value: Array<FileDescriptorProto>): void;
+  addFile(value?: FileDescriptorProto, index?: number): FileDescriptorProto;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FileDescriptorSet.AsObject;
-    static toObject(includeInstance: boolean, msg: FileDescriptorSet): FileDescriptorSet.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FileDescriptorSet, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FileDescriptorSet;
-    static deserializeBinaryFromReader(message: FileDescriptorSet, reader: jspb.BinaryReader): FileDescriptorSet;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FileDescriptorSet.AsObject;
+  static toObject(includeInstance: boolean, msg: FileDescriptorSet): FileDescriptorSet.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FileDescriptorSet, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FileDescriptorSet;
+  static deserializeBinaryFromReader(message: FileDescriptorSet, reader: jspb.BinaryReader): FileDescriptorSet;
 }
 
 export namespace FileDescriptorSet {
-    export type AsObject = {
-        fileList: Array<FileDescriptorProto.AsObject>,
-    }
+  export type AsObject = {
+    fileList: Array<FileDescriptorProto.AsObject>,
+  }
 }
 
-export class FileDescriptorProto extends jspb.Message { 
+export class FileDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  hasPackage(): boolean;
+  clearPackage(): void;
+  getPackage(): string | undefined;
+  setPackage(value: string): void;
 
+  clearDependencyList(): void;
+  getDependencyList(): Array<string>;
+  setDependencyList(value: Array<string>): void;
+  addDependency(value: string, index?: number): string;
 
-    hasPackage(): boolean;
-    clearPackage(): void;
-    getPackage(): string | undefined;
-    setPackage(value: string): void;
+  clearPublicDependencyList(): void;
+  getPublicDependencyList(): Array<number>;
+  setPublicDependencyList(value: Array<number>): void;
+  addPublicDependency(value: number, index?: number): number;
 
-    clearDependencyList(): void;
-    getDependencyList(): Array<string>;
-    setDependencyList(value: Array<string>): void;
-    addDependency(value: string, index?: number): string;
+  clearWeakDependencyList(): void;
+  getWeakDependencyList(): Array<number>;
+  setWeakDependencyList(value: Array<number>): void;
+  addWeakDependency(value: number, index?: number): number;
 
-    clearPublicDependencyList(): void;
-    getPublicDependencyList(): Array<number>;
-    setPublicDependencyList(value: Array<number>): void;
-    addPublicDependency(value: number, index?: number): number;
+  clearMessageTypeList(): void;
+  getMessageTypeList(): Array<DescriptorProto>;
+  setMessageTypeList(value: Array<DescriptorProto>): void;
+  addMessageType(value?: DescriptorProto, index?: number): DescriptorProto;
 
-    clearWeakDependencyList(): void;
-    getWeakDependencyList(): Array<number>;
-    setWeakDependencyList(value: Array<number>): void;
-    addWeakDependency(value: number, index?: number): number;
+  clearEnumTypeList(): void;
+  getEnumTypeList(): Array<EnumDescriptorProto>;
+  setEnumTypeList(value: Array<EnumDescriptorProto>): void;
+  addEnumType(value?: EnumDescriptorProto, index?: number): EnumDescriptorProto;
 
-    clearMessageTypeList(): void;
-    getMessageTypeList(): Array<DescriptorProto>;
-    setMessageTypeList(value: Array<DescriptorProto>): void;
-    addMessageType(value?: DescriptorProto, index?: number): DescriptorProto;
+  clearServiceList(): void;
+  getServiceList(): Array<ServiceDescriptorProto>;
+  setServiceList(value: Array<ServiceDescriptorProto>): void;
+  addService(value?: ServiceDescriptorProto, index?: number): ServiceDescriptorProto;
 
-    clearEnumTypeList(): void;
-    getEnumTypeList(): Array<EnumDescriptorProto>;
-    setEnumTypeList(value: Array<EnumDescriptorProto>): void;
-    addEnumType(value?: EnumDescriptorProto, index?: number): EnumDescriptorProto;
+  clearExtensionList(): void;
+  getExtensionList(): Array<FieldDescriptorProto>;
+  setExtensionList(value: Array<FieldDescriptorProto>): void;
+  addExtension(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
 
-    clearServiceList(): void;
-    getServiceList(): Array<ServiceDescriptorProto>;
-    setServiceList(value: Array<ServiceDescriptorProto>): void;
-    addService(value?: ServiceDescriptorProto, index?: number): ServiceDescriptorProto;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): FileOptions | undefined;
+  setOptions(value?: FileOptions): void;
 
-    clearExtensionList(): void;
-    getExtensionList(): Array<FieldDescriptorProto>;
-    setExtensionList(value: Array<FieldDescriptorProto>): void;
-    addExtension(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
+  hasSourceCodeInfo(): boolean;
+  clearSourceCodeInfo(): void;
+  getSourceCodeInfo(): SourceCodeInfo | undefined;
+  setSourceCodeInfo(value?: SourceCodeInfo): void;
 
+  hasSyntax(): boolean;
+  clearSyntax(): void;
+  getSyntax(): string | undefined;
+  setSyntax(value: string): void;
 
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): FileOptions | undefined;
-    setOptions(value?: FileOptions): void;
-
-
-    hasSourceCodeInfo(): boolean;
-    clearSourceCodeInfo(): void;
-    getSourceCodeInfo(): SourceCodeInfo | undefined;
-    setSourceCodeInfo(value?: SourceCodeInfo): void;
-
-
-    hasSyntax(): boolean;
-    clearSyntax(): void;
-    getSyntax(): string | undefined;
-    setSyntax(value: string): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FileDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: FileDescriptorProto): FileDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FileDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FileDescriptorProto;
-    static deserializeBinaryFromReader(message: FileDescriptorProto, reader: jspb.BinaryReader): FileDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FileDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: FileDescriptorProto): FileDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FileDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FileDescriptorProto;
+  static deserializeBinaryFromReader(message: FileDescriptorProto, reader: jspb.BinaryReader): FileDescriptorProto;
 }
 
 export namespace FileDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        pb_package?: string,
-        dependencyList: Array<string>,
-        publicDependencyList: Array<number>,
-        weakDependencyList: Array<number>,
-        messageTypeList: Array<DescriptorProto.AsObject>,
-        enumTypeList: Array<EnumDescriptorProto.AsObject>,
-        serviceList: Array<ServiceDescriptorProto.AsObject>,
-        extensionList: Array<FieldDescriptorProto.AsObject>,
-        options?: FileOptions.AsObject,
-        sourceCodeInfo?: SourceCodeInfo.AsObject,
-        syntax?: string,
-    }
+  export type AsObject = {
+    name?: string,
+    pb_package?: string,
+    dependencyList: Array<string>,
+    publicDependencyList: Array<number>,
+    weakDependencyList: Array<number>,
+    messageTypeList: Array<DescriptorProto.AsObject>,
+    enumTypeList: Array<EnumDescriptorProto.AsObject>,
+    serviceList: Array<ServiceDescriptorProto.AsObject>,
+    extensionList: Array<FieldDescriptorProto.AsObject>,
+    options?: FileOptions.AsObject,
+    sourceCodeInfo?: SourceCodeInfo.AsObject,
+    syntax?: string,
+  }
 }
 
-export class DescriptorProto extends jspb.Message { 
+export class DescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  clearFieldList(): void;
+  getFieldList(): Array<FieldDescriptorProto>;
+  setFieldList(value: Array<FieldDescriptorProto>): void;
+  addField(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
 
-    clearFieldList(): void;
-    getFieldList(): Array<FieldDescriptorProto>;
-    setFieldList(value: Array<FieldDescriptorProto>): void;
-    addField(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
+  clearExtensionList(): void;
+  getExtensionList(): Array<FieldDescriptorProto>;
+  setExtensionList(value: Array<FieldDescriptorProto>): void;
+  addExtension(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
 
-    clearExtensionList(): void;
-    getExtensionList(): Array<FieldDescriptorProto>;
-    setExtensionList(value: Array<FieldDescriptorProto>): void;
-    addExtension(value?: FieldDescriptorProto, index?: number): FieldDescriptorProto;
+  clearNestedTypeList(): void;
+  getNestedTypeList(): Array<DescriptorProto>;
+  setNestedTypeList(value: Array<DescriptorProto>): void;
+  addNestedType(value?: DescriptorProto, index?: number): DescriptorProto;
 
-    clearNestedTypeList(): void;
-    getNestedTypeList(): Array<DescriptorProto>;
-    setNestedTypeList(value: Array<DescriptorProto>): void;
-    addNestedType(value?: DescriptorProto, index?: number): DescriptorProto;
+  clearEnumTypeList(): void;
+  getEnumTypeList(): Array<EnumDescriptorProto>;
+  setEnumTypeList(value: Array<EnumDescriptorProto>): void;
+  addEnumType(value?: EnumDescriptorProto, index?: number): EnumDescriptorProto;
 
-    clearEnumTypeList(): void;
-    getEnumTypeList(): Array<EnumDescriptorProto>;
-    setEnumTypeList(value: Array<EnumDescriptorProto>): void;
-    addEnumType(value?: EnumDescriptorProto, index?: number): EnumDescriptorProto;
+  clearExtensionRangeList(): void;
+  getExtensionRangeList(): Array<DescriptorProto.ExtensionRange>;
+  setExtensionRangeList(value: Array<DescriptorProto.ExtensionRange>): void;
+  addExtensionRange(value?: DescriptorProto.ExtensionRange, index?: number): DescriptorProto.ExtensionRange;
 
-    clearExtensionRangeList(): void;
-    getExtensionRangeList(): Array<DescriptorProto.ExtensionRange>;
-    setExtensionRangeList(value: Array<DescriptorProto.ExtensionRange>): void;
-    addExtensionRange(value?: DescriptorProto.ExtensionRange, index?: number): DescriptorProto.ExtensionRange;
+  clearOneofDeclList(): void;
+  getOneofDeclList(): Array<OneofDescriptorProto>;
+  setOneofDeclList(value: Array<OneofDescriptorProto>): void;
+  addOneofDecl(value?: OneofDescriptorProto, index?: number): OneofDescriptorProto;
 
-    clearOneofDeclList(): void;
-    getOneofDeclList(): Array<OneofDescriptorProto>;
-    setOneofDeclList(value: Array<OneofDescriptorProto>): void;
-    addOneofDecl(value?: OneofDescriptorProto, index?: number): OneofDescriptorProto;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): MessageOptions | undefined;
+  setOptions(value?: MessageOptions): void;
 
+  clearReservedRangeList(): void;
+  getReservedRangeList(): Array<DescriptorProto.ReservedRange>;
+  setReservedRangeList(value: Array<DescriptorProto.ReservedRange>): void;
+  addReservedRange(value?: DescriptorProto.ReservedRange, index?: number): DescriptorProto.ReservedRange;
 
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): MessageOptions | undefined;
-    setOptions(value?: MessageOptions): void;
+  clearReservedNameList(): void;
+  getReservedNameList(): Array<string>;
+  setReservedNameList(value: Array<string>): void;
+  addReservedName(value: string, index?: number): string;
 
-    clearReservedRangeList(): void;
-    getReservedRangeList(): Array<DescriptorProto.ReservedRange>;
-    setReservedRangeList(value: Array<DescriptorProto.ReservedRange>): void;
-    addReservedRange(value?: DescriptorProto.ReservedRange, index?: number): DescriptorProto.ReservedRange;
-
-    clearReservedNameList(): void;
-    getReservedNameList(): Array<string>;
-    setReservedNameList(value: Array<string>): void;
-    addReservedName(value: string, index?: number): string;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: DescriptorProto): DescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DescriptorProto;
-    static deserializeBinaryFromReader(message: DescriptorProto, reader: jspb.BinaryReader): DescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: DescriptorProto): DescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DescriptorProto;
+  static deserializeBinaryFromReader(message: DescriptorProto, reader: jspb.BinaryReader): DescriptorProto;
 }
 
 export namespace DescriptorProto {
-    export type AsObject = {
-        name?: string,
-        fieldList: Array<FieldDescriptorProto.AsObject>,
-        extensionList: Array<FieldDescriptorProto.AsObject>,
-        nestedTypeList: Array<DescriptorProto.AsObject>,
-        enumTypeList: Array<EnumDescriptorProto.AsObject>,
-        extensionRangeList: Array<DescriptorProto.ExtensionRange.AsObject>,
-        oneofDeclList: Array<OneofDescriptorProto.AsObject>,
-        options?: MessageOptions.AsObject,
-        reservedRangeList: Array<DescriptorProto.ReservedRange.AsObject>,
-        reservedNameList: Array<string>,
-    }
+  export type AsObject = {
+    name?: string,
+    fieldList: Array<FieldDescriptorProto.AsObject>,
+    extensionList: Array<FieldDescriptorProto.AsObject>,
+    nestedTypeList: Array<DescriptorProto.AsObject>,
+    enumTypeList: Array<EnumDescriptorProto.AsObject>,
+    extensionRangeList: Array<DescriptorProto.ExtensionRange.AsObject>,
+    oneofDeclList: Array<OneofDescriptorProto.AsObject>,
+    options?: MessageOptions.AsObject,
+    reservedRangeList: Array<DescriptorProto.ReservedRange.AsObject>,
+    reservedNameList: Array<string>,
+  }
 
-
-    export class ExtensionRange extends jspb.Message { 
-
+  export class ExtensionRange extends jspb.Message {
     hasStart(): boolean;
     clearStart(): void;
     getStart(): number | undefined;
     setStart(value: number): void;
 
-
     hasEnd(): boolean;
     clearEnd(): void;
     getEnd(): number | undefined;
     setEnd(value: number): void;
-
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): ExtensionRange.AsObject;
-        static toObject(includeInstance: boolean, msg: ExtensionRange): ExtensionRange.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: ExtensionRange, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): ExtensionRange;
-        static deserializeBinaryFromReader(message: ExtensionRange, reader: jspb.BinaryReader): ExtensionRange;
-    }
-
-    export namespace ExtensionRange {
-        export type AsObject = {
-        start?: number,
-        end?: number,
-        }
-    }
-
-    export class ReservedRange extends jspb.Message { 
-
-    hasStart(): boolean;
-    clearStart(): void;
-    getStart(): number | undefined;
-    setStart(value: number): void;
-
-
-    hasEnd(): boolean;
-    clearEnd(): void;
-    getEnd(): number | undefined;
-    setEnd(value: number): void;
-
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): ReservedRange.AsObject;
-        static toObject(includeInstance: boolean, msg: ReservedRange): ReservedRange.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: ReservedRange, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): ReservedRange;
-        static deserializeBinaryFromReader(message: ReservedRange, reader: jspb.BinaryReader): ReservedRange;
-    }
-
-    export namespace ReservedRange {
-        export type AsObject = {
-        start?: number,
-        end?: number,
-        }
-    }
-
-}
-
-export class FieldDescriptorProto extends jspb.Message { 
-
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
-
-
-    hasNumber(): boolean;
-    clearNumber(): void;
-    getNumber(): number | undefined;
-    setNumber(value: number): void;
-
-
-    hasLabel(): boolean;
-    clearLabel(): void;
-    getLabel(): FieldDescriptorProto.Label | undefined;
-    setLabel(value: FieldDescriptorProto.Label): void;
-
-
-    hasType(): boolean;
-    clearType(): void;
-    getType(): FieldDescriptorProto.Type | undefined;
-    setType(value: FieldDescriptorProto.Type): void;
-
-
-    hasTypeName(): boolean;
-    clearTypeName(): void;
-    getTypeName(): string | undefined;
-    setTypeName(value: string): void;
-
-
-    hasExtendee(): boolean;
-    clearExtendee(): void;
-    getExtendee(): string | undefined;
-    setExtendee(value: string): void;
-
-
-    hasDefaultValue(): boolean;
-    clearDefaultValue(): void;
-    getDefaultValue(): string | undefined;
-    setDefaultValue(value: string): void;
-
-
-    hasOneofIndex(): boolean;
-    clearOneofIndex(): void;
-    getOneofIndex(): number | undefined;
-    setOneofIndex(value: number): void;
-
-
-    hasJsonName(): boolean;
-    clearJsonName(): void;
-    getJsonName(): string | undefined;
-    setJsonName(value: string): void;
-
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): FieldOptions | undefined;
-    setOptions(value?: FieldOptions): void;
-
 
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FieldDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: FieldDescriptorProto): FieldDescriptorProto.AsObject;
+    toObject(includeInstance?: boolean): ExtensionRange.AsObject;
+    static toObject(includeInstance: boolean, msg: ExtensionRange): ExtensionRange.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FieldDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FieldDescriptorProto;
-    static deserializeBinaryFromReader(message: FieldDescriptorProto, reader: jspb.BinaryReader): FieldDescriptorProto;
+    static serializeBinaryToWriter(message: ExtensionRange, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ExtensionRange;
+    static deserializeBinaryFromReader(message: ExtensionRange, reader: jspb.BinaryReader): ExtensionRange;
+  }
+
+  export namespace ExtensionRange {
+    export type AsObject = {
+      start?: number,
+      end?: number,
+    }
+  }
+
+  export class ReservedRange extends jspb.Message {
+    hasStart(): boolean;
+    clearStart(): void;
+    getStart(): number | undefined;
+    setStart(value: number): void;
+
+    hasEnd(): boolean;
+    clearEnd(): void;
+    getEnd(): number | undefined;
+    setEnd(value: number): void;
+
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ReservedRange.AsObject;
+    static toObject(includeInstance: boolean, msg: ReservedRange): ReservedRange.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ReservedRange, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ReservedRange;
+    static deserializeBinaryFromReader(message: ReservedRange, reader: jspb.BinaryReader): ReservedRange;
+  }
+
+  export namespace ReservedRange {
+    export type AsObject = {
+      start?: number,
+      end?: number,
+    }
+  }
+}
+
+export class FieldDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
+
+  hasNumber(): boolean;
+  clearNumber(): void;
+  getNumber(): number | undefined;
+  setNumber(value: number): void;
+
+  hasLabel(): boolean;
+  clearLabel(): void;
+  getLabel(): FieldDescriptorProto.Label | undefined;
+  setLabel(value: FieldDescriptorProto.Label): void;
+
+  hasType(): boolean;
+  clearType(): void;
+  getType(): FieldDescriptorProto.Type | undefined;
+  setType(value: FieldDescriptorProto.Type): void;
+
+  hasTypeName(): boolean;
+  clearTypeName(): void;
+  getTypeName(): string | undefined;
+  setTypeName(value: string): void;
+
+  hasExtendee(): boolean;
+  clearExtendee(): void;
+  getExtendee(): string | undefined;
+  setExtendee(value: string): void;
+
+  hasDefaultValue(): boolean;
+  clearDefaultValue(): void;
+  getDefaultValue(): string | undefined;
+  setDefaultValue(value: string): void;
+
+  hasOneofIndex(): boolean;
+  clearOneofIndex(): void;
+  getOneofIndex(): number | undefined;
+  setOneofIndex(value: number): void;
+
+  hasJsonName(): boolean;
+  clearJsonName(): void;
+  getJsonName(): string | undefined;
+  setJsonName(value: string): void;
+
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): FieldOptions | undefined;
+  setOptions(value?: FieldOptions): void;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FieldDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: FieldDescriptorProto): FieldDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FieldDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FieldDescriptorProto;
+  static deserializeBinaryFromReader(message: FieldDescriptorProto, reader: jspb.BinaryReader): FieldDescriptorProto;
 }
 
 export namespace FieldDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        number?: number,
-        label?: FieldDescriptorProto.Label,
-        type?: FieldDescriptorProto.Type,
-        typeName?: string,
-        extendee?: string,
-        defaultValue?: string,
-        oneofIndex?: number,
-        jsonName?: string,
-        options?: FieldOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    number?: number,
+    label?: FieldDescriptorProto.Label,
+    type?: FieldDescriptorProto.Type,
+    typeName?: string,
+    extendee?: string,
+    defaultValue?: string,
+    oneofIndex?: number,
+    jsonName?: string,
+    options?: FieldOptions.AsObject,
+  }
 
-    export enum Type {
+  export enum Type {
     TYPE_DOUBLE = 1,
     TYPE_FLOAT = 2,
     TYPE_INT64 = 3,
@@ -370,791 +339,711 @@ export namespace FieldDescriptorProto {
     TYPE_SFIXED64 = 16,
     TYPE_SINT32 = 17,
     TYPE_SINT64 = 18,
-    }
+  }
 
-    export enum Label {
+  export enum Label {
     LABEL_OPTIONAL = 1,
     LABEL_REQUIRED = 2,
     LABEL_REPEATED = 3,
-    }
-
+  }
 }
 
-export class OneofDescriptorProto extends jspb.Message { 
+export class OneofDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): OneofOptions | undefined;
+  setOptions(value?: OneofOptions): void;
 
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): OneofOptions | undefined;
-    setOptions(value?: OneofOptions): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OneofDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: OneofDescriptorProto): OneofDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OneofDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OneofDescriptorProto;
-    static deserializeBinaryFromReader(message: OneofDescriptorProto, reader: jspb.BinaryReader): OneofDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OneofDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: OneofDescriptorProto): OneofDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OneofDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OneofDescriptorProto;
+  static deserializeBinaryFromReader(message: OneofDescriptorProto, reader: jspb.BinaryReader): OneofDescriptorProto;
 }
 
 export namespace OneofDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        options?: OneofOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    options?: OneofOptions.AsObject,
+  }
 }
 
-export class EnumDescriptorProto extends jspb.Message { 
+export class EnumDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  clearValueList(): void;
+  getValueList(): Array<EnumValueDescriptorProto>;
+  setValueList(value: Array<EnumValueDescriptorProto>): void;
+  addValue(value?: EnumValueDescriptorProto, index?: number): EnumValueDescriptorProto;
 
-    clearValueList(): void;
-    getValueList(): Array<EnumValueDescriptorProto>;
-    setValueList(value: Array<EnumValueDescriptorProto>): void;
-    addValue(value?: EnumValueDescriptorProto, index?: number): EnumValueDescriptorProto;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): EnumOptions | undefined;
+  setOptions(value?: EnumOptions): void;
 
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): EnumOptions | undefined;
-    setOptions(value?: EnumOptions): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): EnumDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: EnumDescriptorProto): EnumDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: EnumDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): EnumDescriptorProto;
-    static deserializeBinaryFromReader(message: EnumDescriptorProto, reader: jspb.BinaryReader): EnumDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): EnumDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumDescriptorProto): EnumDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumDescriptorProto;
+  static deserializeBinaryFromReader(message: EnumDescriptorProto, reader: jspb.BinaryReader): EnumDescriptorProto;
 }
 
 export namespace EnumDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        valueList: Array<EnumValueDescriptorProto.AsObject>,
-        options?: EnumOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    valueList: Array<EnumValueDescriptorProto.AsObject>,
+    options?: EnumOptions.AsObject,
+  }
 }
 
-export class EnumValueDescriptorProto extends jspb.Message { 
+export class EnumValueDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  hasNumber(): boolean;
+  clearNumber(): void;
+  getNumber(): number | undefined;
+  setNumber(value: number): void;
 
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): EnumValueOptions | undefined;
+  setOptions(value?: EnumValueOptions): void;
 
-    hasNumber(): boolean;
-    clearNumber(): void;
-    getNumber(): number | undefined;
-    setNumber(value: number): void;
-
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): EnumValueOptions | undefined;
-    setOptions(value?: EnumValueOptions): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): EnumValueDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: EnumValueDescriptorProto): EnumValueDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: EnumValueDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): EnumValueDescriptorProto;
-    static deserializeBinaryFromReader(message: EnumValueDescriptorProto, reader: jspb.BinaryReader): EnumValueDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): EnumValueDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumValueDescriptorProto): EnumValueDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumValueDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumValueDescriptorProto;
+  static deserializeBinaryFromReader(message: EnumValueDescriptorProto, reader: jspb.BinaryReader): EnumValueDescriptorProto;
 }
 
 export namespace EnumValueDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        number?: number,
-        options?: EnumValueOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    number?: number,
+    options?: EnumValueOptions.AsObject,
+  }
 }
 
-export class ServiceDescriptorProto extends jspb.Message { 
+export class ServiceDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  clearMethodList(): void;
+  getMethodList(): Array<MethodDescriptorProto>;
+  setMethodList(value: Array<MethodDescriptorProto>): void;
+  addMethod(value?: MethodDescriptorProto, index?: number): MethodDescriptorProto;
 
-    clearMethodList(): void;
-    getMethodList(): Array<MethodDescriptorProto>;
-    setMethodList(value: Array<MethodDescriptorProto>): void;
-    addMethod(value?: MethodDescriptorProto, index?: number): MethodDescriptorProto;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): ServiceOptions | undefined;
+  setOptions(value?: ServiceOptions): void;
 
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): ServiceOptions | undefined;
-    setOptions(value?: ServiceOptions): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ServiceDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: ServiceDescriptorProto): ServiceDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ServiceDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ServiceDescriptorProto;
-    static deserializeBinaryFromReader(message: ServiceDescriptorProto, reader: jspb.BinaryReader): ServiceDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ServiceDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: ServiceDescriptorProto): ServiceDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ServiceDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ServiceDescriptorProto;
+  static deserializeBinaryFromReader(message: ServiceDescriptorProto, reader: jspb.BinaryReader): ServiceDescriptorProto;
 }
 
 export namespace ServiceDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        methodList: Array<MethodDescriptorProto.AsObject>,
-        options?: ServiceOptions.AsObject,
-    }
+  export type AsObject = {
+    name?: string,
+    methodList: Array<MethodDescriptorProto.AsObject>,
+    options?: ServiceOptions.AsObject,
+  }
 }
 
-export class MethodDescriptorProto extends jspb.Message { 
+export class MethodDescriptorProto extends jspb.Message {
+  hasName(): boolean;
+  clearName(): void;
+  getName(): string | undefined;
+  setName(value: string): void;
 
-    hasName(): boolean;
-    clearName(): void;
-    getName(): string | undefined;
-    setName(value: string): void;
+  hasInputType(): boolean;
+  clearInputType(): void;
+  getInputType(): string | undefined;
+  setInputType(value: string): void;
 
+  hasOutputType(): boolean;
+  clearOutputType(): void;
+  getOutputType(): string | undefined;
+  setOutputType(value: string): void;
 
-    hasInputType(): boolean;
-    clearInputType(): void;
-    getInputType(): string | undefined;
-    setInputType(value: string): void;
+  hasOptions(): boolean;
+  clearOptions(): void;
+  getOptions(): MethodOptions | undefined;
+  setOptions(value?: MethodOptions): void;
 
+  hasClientStreaming(): boolean;
+  clearClientStreaming(): void;
+  getClientStreaming(): boolean | undefined;
+  setClientStreaming(value: boolean): void;
 
-    hasOutputType(): boolean;
-    clearOutputType(): void;
-    getOutputType(): string | undefined;
-    setOutputType(value: string): void;
+  hasServerStreaming(): boolean;
+  clearServerStreaming(): void;
+  getServerStreaming(): boolean | undefined;
+  setServerStreaming(value: boolean): void;
 
-
-    hasOptions(): boolean;
-    clearOptions(): void;
-    getOptions(): MethodOptions | undefined;
-    setOptions(value?: MethodOptions): void;
-
-
-    hasClientStreaming(): boolean;
-    clearClientStreaming(): void;
-    getClientStreaming(): boolean | undefined;
-    setClientStreaming(value: boolean): void;
-
-
-    hasServerStreaming(): boolean;
-    clearServerStreaming(): void;
-    getServerStreaming(): boolean | undefined;
-    setServerStreaming(value: boolean): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): MethodDescriptorProto.AsObject;
-    static toObject(includeInstance: boolean, msg: MethodDescriptorProto): MethodDescriptorProto.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: MethodDescriptorProto, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): MethodDescriptorProto;
-    static deserializeBinaryFromReader(message: MethodDescriptorProto, reader: jspb.BinaryReader): MethodDescriptorProto;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): MethodDescriptorProto.AsObject;
+  static toObject(includeInstance: boolean, msg: MethodDescriptorProto): MethodDescriptorProto.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MethodDescriptorProto, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MethodDescriptorProto;
+  static deserializeBinaryFromReader(message: MethodDescriptorProto, reader: jspb.BinaryReader): MethodDescriptorProto;
 }
 
 export namespace MethodDescriptorProto {
-    export type AsObject = {
-        name?: string,
-        inputType?: string,
-        outputType?: string,
-        options?: MethodOptions.AsObject,
-        clientStreaming?: boolean,
-        serverStreaming?: boolean,
-    }
+  export type AsObject = {
+    name?: string,
+    inputType?: string,
+    outputType?: string,
+    options?: MethodOptions.AsObject,
+    clientStreaming?: boolean,
+    serverStreaming?: boolean,
+  }
 }
 
-export class FileOptions extends jspb.Message { 
+export class FileOptions extends jspb.Message {
+  hasJavaPackage(): boolean;
+  clearJavaPackage(): void;
+  getJavaPackage(): string | undefined;
+  setJavaPackage(value: string): void;
 
-    hasJavaPackage(): boolean;
-    clearJavaPackage(): void;
-    getJavaPackage(): string | undefined;
-    setJavaPackage(value: string): void;
+  hasJavaOuterClassname(): boolean;
+  clearJavaOuterClassname(): void;
+  getJavaOuterClassname(): string | undefined;
+  setJavaOuterClassname(value: string): void;
 
+  hasJavaMultipleFiles(): boolean;
+  clearJavaMultipleFiles(): void;
+  getJavaMultipleFiles(): boolean | undefined;
+  setJavaMultipleFiles(value: boolean): void;
 
-    hasJavaOuterClassname(): boolean;
-    clearJavaOuterClassname(): void;
-    getJavaOuterClassname(): string | undefined;
-    setJavaOuterClassname(value: string): void;
+  hasJavaGenerateEqualsAndHash(): boolean;
+  clearJavaGenerateEqualsAndHash(): void;
+  getJavaGenerateEqualsAndHash(): boolean | undefined;
+  setJavaGenerateEqualsAndHash(value: boolean): void;
 
+  hasJavaStringCheckUtf8(): boolean;
+  clearJavaStringCheckUtf8(): void;
+  getJavaStringCheckUtf8(): boolean | undefined;
+  setJavaStringCheckUtf8(value: boolean): void;
 
-    hasJavaMultipleFiles(): boolean;
-    clearJavaMultipleFiles(): void;
-    getJavaMultipleFiles(): boolean | undefined;
-    setJavaMultipleFiles(value: boolean): void;
+  hasOptimizeFor(): boolean;
+  clearOptimizeFor(): void;
+  getOptimizeFor(): FileOptions.OptimizeMode | undefined;
+  setOptimizeFor(value: FileOptions.OptimizeMode): void;
 
+  hasGoPackage(): boolean;
+  clearGoPackage(): void;
+  getGoPackage(): string | undefined;
+  setGoPackage(value: string): void;
 
-    hasJavaGenerateEqualsAndHash(): boolean;
-    clearJavaGenerateEqualsAndHash(): void;
-    getJavaGenerateEqualsAndHash(): boolean | undefined;
-    setJavaGenerateEqualsAndHash(value: boolean): void;
+  hasCcGenericServices(): boolean;
+  clearCcGenericServices(): void;
+  getCcGenericServices(): boolean | undefined;
+  setCcGenericServices(value: boolean): void;
 
+  hasJavaGenericServices(): boolean;
+  clearJavaGenericServices(): void;
+  getJavaGenericServices(): boolean | undefined;
+  setJavaGenericServices(value: boolean): void;
 
-    hasJavaStringCheckUtf8(): boolean;
-    clearJavaStringCheckUtf8(): void;
-    getJavaStringCheckUtf8(): boolean | undefined;
-    setJavaStringCheckUtf8(value: boolean): void;
+  hasPyGenericServices(): boolean;
+  clearPyGenericServices(): void;
+  getPyGenericServices(): boolean | undefined;
+  setPyGenericServices(value: boolean): void;
 
+  hasPhpGenericServices(): boolean;
+  clearPhpGenericServices(): void;
+  getPhpGenericServices(): boolean | undefined;
+  setPhpGenericServices(value: boolean): void;
 
-    hasOptimizeFor(): boolean;
-    clearOptimizeFor(): void;
-    getOptimizeFor(): FileOptions.OptimizeMode | undefined;
-    setOptimizeFor(value: FileOptions.OptimizeMode): void;
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
+  hasCcEnableArenas(): boolean;
+  clearCcEnableArenas(): void;
+  getCcEnableArenas(): boolean | undefined;
+  setCcEnableArenas(value: boolean): void;
 
-    hasGoPackage(): boolean;
-    clearGoPackage(): void;
-    getGoPackage(): string | undefined;
-    setGoPackage(value: string): void;
+  hasObjcClassPrefix(): boolean;
+  clearObjcClassPrefix(): void;
+  getObjcClassPrefix(): string | undefined;
+  setObjcClassPrefix(value: string): void;
 
+  hasCsharpNamespace(): boolean;
+  clearCsharpNamespace(): void;
+  getCsharpNamespace(): string | undefined;
+  setCsharpNamespace(value: string): void;
 
-    hasCcGenericServices(): boolean;
-    clearCcGenericServices(): void;
-    getCcGenericServices(): boolean | undefined;
-    setCcGenericServices(value: boolean): void;
+  hasSwiftPrefix(): boolean;
+  clearSwiftPrefix(): void;
+  getSwiftPrefix(): string | undefined;
+  setSwiftPrefix(value: string): void;
 
+  hasPhpClassPrefix(): boolean;
+  clearPhpClassPrefix(): void;
+  getPhpClassPrefix(): string | undefined;
+  setPhpClassPrefix(value: string): void;
 
-    hasJavaGenericServices(): boolean;
-    clearJavaGenericServices(): void;
-    getJavaGenericServices(): boolean | undefined;
-    setJavaGenericServices(value: boolean): void;
+  hasPhpNamespace(): boolean;
+  clearPhpNamespace(): void;
+  getPhpNamespace(): string | undefined;
+  setPhpNamespace(value: string): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasPyGenericServices(): boolean;
-    clearPyGenericServices(): void;
-    getPyGenericServices(): boolean | undefined;
-    setPyGenericServices(value: boolean): void;
-
-
-    hasPhpGenericServices(): boolean;
-    clearPhpGenericServices(): void;
-    getPhpGenericServices(): boolean | undefined;
-    setPhpGenericServices(value: boolean): void;
-
-
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
-
-
-    hasCcEnableArenas(): boolean;
-    clearCcEnableArenas(): void;
-    getCcEnableArenas(): boolean | undefined;
-    setCcEnableArenas(value: boolean): void;
-
-
-    hasObjcClassPrefix(): boolean;
-    clearObjcClassPrefix(): void;
-    getObjcClassPrefix(): string | undefined;
-    setObjcClassPrefix(value: string): void;
-
-
-    hasCsharpNamespace(): boolean;
-    clearCsharpNamespace(): void;
-    getCsharpNamespace(): string | undefined;
-    setCsharpNamespace(value: string): void;
-
-
-    hasSwiftPrefix(): boolean;
-    clearSwiftPrefix(): void;
-    getSwiftPrefix(): string | undefined;
-    setSwiftPrefix(value: string): void;
-
-
-    hasPhpClassPrefix(): boolean;
-    clearPhpClassPrefix(): void;
-    getPhpClassPrefix(): string | undefined;
-    setPhpClassPrefix(value: string): void;
-
-
-    hasPhpNamespace(): boolean;
-    clearPhpNamespace(): void;
-    getPhpNamespace(): string | undefined;
-    setPhpNamespace(value: string): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FileOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: FileOptions): FileOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FileOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FileOptions;
-    static deserializeBinaryFromReader(message: FileOptions, reader: jspb.BinaryReader): FileOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FileOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: FileOptions): FileOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FileOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FileOptions;
+  static deserializeBinaryFromReader(message: FileOptions, reader: jspb.BinaryReader): FileOptions;
 }
 
 export namespace FileOptions {
-    export type AsObject = {
-        javaPackage?: string,
-        javaOuterClassname?: string,
-        javaMultipleFiles?: boolean,
-        javaGenerateEqualsAndHash?: boolean,
-        javaStringCheckUtf8?: boolean,
-        optimizeFor?: FileOptions.OptimizeMode,
-        goPackage?: string,
-        ccGenericServices?: boolean,
-        javaGenericServices?: boolean,
-        pyGenericServices?: boolean,
-        phpGenericServices?: boolean,
-        deprecated?: boolean,
-        ccEnableArenas?: boolean,
-        objcClassPrefix?: string,
-        csharpNamespace?: string,
-        swiftPrefix?: string,
-        phpClassPrefix?: string,
-        phpNamespace?: string,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    javaPackage?: string,
+    javaOuterClassname?: string,
+    javaMultipleFiles?: boolean,
+    javaGenerateEqualsAndHash?: boolean,
+    javaStringCheckUtf8?: boolean,
+    optimizeFor?: FileOptions.OptimizeMode,
+    goPackage?: string,
+    ccGenericServices?: boolean,
+    javaGenericServices?: boolean,
+    pyGenericServices?: boolean,
+    phpGenericServices?: boolean,
+    deprecated?: boolean,
+    ccEnableArenas?: boolean,
+    objcClassPrefix?: string,
+    csharpNamespace?: string,
+    swiftPrefix?: string,
+    phpClassPrefix?: string,
+    phpNamespace?: string,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 
-    export enum OptimizeMode {
+  export enum OptimizeMode {
     SPEED = 1,
     CODE_SIZE = 2,
     LITE_RUNTIME = 3,
-    }
-
+  }
 }
 
-export class MessageOptions extends jspb.Message { 
+export class MessageOptions extends jspb.Message {
+  hasMessageSetWireFormat(): boolean;
+  clearMessageSetWireFormat(): void;
+  getMessageSetWireFormat(): boolean | undefined;
+  setMessageSetWireFormat(value: boolean): void;
 
-    hasMessageSetWireFormat(): boolean;
-    clearMessageSetWireFormat(): void;
-    getMessageSetWireFormat(): boolean | undefined;
-    setMessageSetWireFormat(value: boolean): void;
+  hasNoStandardDescriptorAccessor(): boolean;
+  clearNoStandardDescriptorAccessor(): void;
+  getNoStandardDescriptorAccessor(): boolean | undefined;
+  setNoStandardDescriptorAccessor(value: boolean): void;
 
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasNoStandardDescriptorAccessor(): boolean;
-    clearNoStandardDescriptorAccessor(): void;
-    getNoStandardDescriptorAccessor(): boolean | undefined;
-    setNoStandardDescriptorAccessor(value: boolean): void;
+  hasMapEntry(): boolean;
+  clearMapEntry(): void;
+  getMapEntry(): boolean | undefined;
+  setMapEntry(value: boolean): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
-
-
-    hasMapEntry(): boolean;
-    clearMapEntry(): void;
-    getMapEntry(): boolean | undefined;
-    setMapEntry(value: boolean): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): MessageOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: MessageOptions): MessageOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: MessageOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): MessageOptions;
-    static deserializeBinaryFromReader(message: MessageOptions, reader: jspb.BinaryReader): MessageOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): MessageOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: MessageOptions): MessageOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MessageOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MessageOptions;
+  static deserializeBinaryFromReader(message: MessageOptions, reader: jspb.BinaryReader): MessageOptions;
 }
 
 export namespace MessageOptions {
-    export type AsObject = {
-        messageSetWireFormat?: boolean,
-        noStandardDescriptorAccessor?: boolean,
-        deprecated?: boolean,
-        mapEntry?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    messageSetWireFormat?: boolean,
+    noStandardDescriptorAccessor?: boolean,
+    deprecated?: boolean,
+    mapEntry?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class FieldOptions extends jspb.Message { 
+export class FieldOptions extends jspb.Message {
+  hasCtype(): boolean;
+  clearCtype(): void;
+  getCtype(): FieldOptions.CType | undefined;
+  setCtype(value: FieldOptions.CType): void;
 
-    hasCtype(): boolean;
-    clearCtype(): void;
-    getCtype(): FieldOptions.CType | undefined;
-    setCtype(value: FieldOptions.CType): void;
+  hasPacked(): boolean;
+  clearPacked(): void;
+  getPacked(): boolean | undefined;
+  setPacked(value: boolean): void;
 
+  hasJstype(): boolean;
+  clearJstype(): void;
+  getJstype(): FieldOptions.JSType | undefined;
+  setJstype(value: FieldOptions.JSType): void;
 
-    hasPacked(): boolean;
-    clearPacked(): void;
-    getPacked(): boolean | undefined;
-    setPacked(value: boolean): void;
+  hasLazy(): boolean;
+  clearLazy(): void;
+  getLazy(): boolean | undefined;
+  setLazy(value: boolean): void;
 
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasJstype(): boolean;
-    clearJstype(): void;
-    getJstype(): FieldOptions.JSType | undefined;
-    setJstype(value: FieldOptions.JSType): void;
+  hasWeak(): boolean;
+  clearWeak(): void;
+  getWeak(): boolean | undefined;
+  setWeak(value: boolean): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasLazy(): boolean;
-    clearLazy(): void;
-    getLazy(): boolean | undefined;
-    setLazy(value: boolean): void;
-
-
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
-
-
-    hasWeak(): boolean;
-    clearWeak(): void;
-    getWeak(): boolean | undefined;
-    setWeak(value: boolean): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FieldOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: FieldOptions): FieldOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FieldOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FieldOptions;
-    static deserializeBinaryFromReader(message: FieldOptions, reader: jspb.BinaryReader): FieldOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FieldOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: FieldOptions): FieldOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FieldOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FieldOptions;
+  static deserializeBinaryFromReader(message: FieldOptions, reader: jspb.BinaryReader): FieldOptions;
 }
 
 export namespace FieldOptions {
-    export type AsObject = {
-        ctype?: FieldOptions.CType,
-        packed?: boolean,
-        jstype?: FieldOptions.JSType,
-        lazy?: boolean,
-        deprecated?: boolean,
-        weak?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    ctype?: FieldOptions.CType,
+    packed?: boolean,
+    jstype?: FieldOptions.JSType,
+    lazy?: boolean,
+    deprecated?: boolean,
+    weak?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 
-    export enum CType {
+  export enum CType {
     STRING = 0,
     CORD = 1,
     STRING_PIECE = 2,
-    }
+  }
 
-    export enum JSType {
+  export enum JSType {
     JS_NORMAL = 0,
     JS_STRING = 1,
     JS_NUMBER = 2,
-    }
-
+  }
 }
 
-export class OneofOptions extends jspb.Message { 
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
+export class OneofOptions extends jspb.Message {
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OneofOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: OneofOptions): OneofOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OneofOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OneofOptions;
-    static deserializeBinaryFromReader(message: OneofOptions, reader: jspb.BinaryReader): OneofOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OneofOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: OneofOptions): OneofOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OneofOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OneofOptions;
+  static deserializeBinaryFromReader(message: OneofOptions, reader: jspb.BinaryReader): OneofOptions;
 }
 
 export namespace OneofOptions {
-    export type AsObject = {
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class EnumOptions extends jspb.Message { 
+export class EnumOptions extends jspb.Message {
+  hasAllowAlias(): boolean;
+  clearAllowAlias(): void;
+  getAllowAlias(): boolean | undefined;
+  setAllowAlias(value: boolean): void;
 
-    hasAllowAlias(): boolean;
-    clearAllowAlias(): void;
-    getAllowAlias(): boolean | undefined;
-    setAllowAlias(value: boolean): void;
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): EnumOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: EnumOptions): EnumOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: EnumOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): EnumOptions;
-    static deserializeBinaryFromReader(message: EnumOptions, reader: jspb.BinaryReader): EnumOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): EnumOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumOptions): EnumOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumOptions;
+  static deserializeBinaryFromReader(message: EnumOptions, reader: jspb.BinaryReader): EnumOptions;
 }
 
 export namespace EnumOptions {
-    export type AsObject = {
-        allowAlias?: boolean,
-        deprecated?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    allowAlias?: boolean,
+    deprecated?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class EnumValueOptions extends jspb.Message { 
+export class EnumValueOptions extends jspb.Message {
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): EnumValueOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: EnumValueOptions): EnumValueOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: EnumValueOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): EnumValueOptions;
-    static deserializeBinaryFromReader(message: EnumValueOptions, reader: jspb.BinaryReader): EnumValueOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): EnumValueOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: EnumValueOptions): EnumValueOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: EnumValueOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): EnumValueOptions;
+  static deserializeBinaryFromReader(message: EnumValueOptions, reader: jspb.BinaryReader): EnumValueOptions;
 }
 
 export namespace EnumValueOptions {
-    export type AsObject = {
-        deprecated?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    deprecated?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class ServiceOptions extends jspb.Message { 
+export class ServiceOptions extends jspb.Message {
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ServiceOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: ServiceOptions): ServiceOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ServiceOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ServiceOptions;
-    static deserializeBinaryFromReader(message: ServiceOptions, reader: jspb.BinaryReader): ServiceOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ServiceOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: ServiceOptions): ServiceOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ServiceOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ServiceOptions;
+  static deserializeBinaryFromReader(message: ServiceOptions, reader: jspb.BinaryReader): ServiceOptions;
 }
 
 export namespace ServiceOptions {
-    export type AsObject = {
-        deprecated?: boolean,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    deprecated?: boolean,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 }
 
-export class MethodOptions extends jspb.Message { 
+export class MethodOptions extends jspb.Message {
+  hasDeprecated(): boolean;
+  clearDeprecated(): void;
+  getDeprecated(): boolean | undefined;
+  setDeprecated(value: boolean): void;
 
-    hasDeprecated(): boolean;
-    clearDeprecated(): void;
-    getDeprecated(): boolean | undefined;
-    setDeprecated(value: boolean): void;
+  hasIdempotencyLevel(): boolean;
+  clearIdempotencyLevel(): void;
+  getIdempotencyLevel(): MethodOptions.IdempotencyLevel | undefined;
+  setIdempotencyLevel(value: MethodOptions.IdempotencyLevel): void;
 
+  clearUninterpretedOptionList(): void;
+  getUninterpretedOptionList(): Array<UninterpretedOption>;
+  setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
+  addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
 
-    hasIdempotencyLevel(): boolean;
-    clearIdempotencyLevel(): void;
-    getIdempotencyLevel(): MethodOptions.IdempotencyLevel | undefined;
-    setIdempotencyLevel(value: MethodOptions.IdempotencyLevel): void;
-
-    clearUninterpretedOptionList(): void;
-    getUninterpretedOptionList(): Array<UninterpretedOption>;
-    setUninterpretedOptionList(value: Array<UninterpretedOption>): void;
-    addUninterpretedOption(value?: UninterpretedOption, index?: number): UninterpretedOption;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): MethodOptions.AsObject;
-    static toObject(includeInstance: boolean, msg: MethodOptions): MethodOptions.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: MethodOptions, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): MethodOptions;
-    static deserializeBinaryFromReader(message: MethodOptions, reader: jspb.BinaryReader): MethodOptions;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): MethodOptions.AsObject;
+  static toObject(includeInstance: boolean, msg: MethodOptions): MethodOptions.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: MethodOptions, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): MethodOptions;
+  static deserializeBinaryFromReader(message: MethodOptions, reader: jspb.BinaryReader): MethodOptions;
 }
 
 export namespace MethodOptions {
-    export type AsObject = {
-        deprecated?: boolean,
-        idempotencyLevel?: MethodOptions.IdempotencyLevel,
-        uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
-    }
+  export type AsObject = {
+    deprecated?: boolean,
+    idempotencyLevel?: MethodOptions.IdempotencyLevel,
+    uninterpretedOptionList: Array<UninterpretedOption.AsObject>,
+  }
 
-    export enum IdempotencyLevel {
+  export enum IdempotencyLevel {
     IDEMPOTENCY_UNKNOWN = 0,
     NO_SIDE_EFFECTS = 1,
     IDEMPOTENT = 2,
-    }
-
+  }
 }
 
-export class UninterpretedOption extends jspb.Message { 
-    clearNameList(): void;
-    getNameList(): Array<UninterpretedOption.NamePart>;
-    setNameList(value: Array<UninterpretedOption.NamePart>): void;
-    addName(value?: UninterpretedOption.NamePart, index?: number): UninterpretedOption.NamePart;
+export class UninterpretedOption extends jspb.Message {
+  clearNameList(): void;
+  getNameList(): Array<UninterpretedOption.NamePart>;
+  setNameList(value: Array<UninterpretedOption.NamePart>): void;
+  addName(value?: UninterpretedOption.NamePart, index?: number): UninterpretedOption.NamePart;
 
+  hasIdentifierValue(): boolean;
+  clearIdentifierValue(): void;
+  getIdentifierValue(): string | undefined;
+  setIdentifierValue(value: string): void;
 
-    hasIdentifierValue(): boolean;
-    clearIdentifierValue(): void;
-    getIdentifierValue(): string | undefined;
-    setIdentifierValue(value: string): void;
+  hasPositiveIntValue(): boolean;
+  clearPositiveIntValue(): void;
+  getPositiveIntValue(): number | undefined;
+  setPositiveIntValue(value: number): void;
 
+  hasNegativeIntValue(): boolean;
+  clearNegativeIntValue(): void;
+  getNegativeIntValue(): number | undefined;
+  setNegativeIntValue(value: number): void;
 
-    hasPositiveIntValue(): boolean;
-    clearPositiveIntValue(): void;
-    getPositiveIntValue(): number | undefined;
-    setPositiveIntValue(value: number): void;
+  hasDoubleValue(): boolean;
+  clearDoubleValue(): void;
+  getDoubleValue(): number | undefined;
+  setDoubleValue(value: number): void;
 
+  hasStringValue(): boolean;
+  clearStringValue(): void;
+  getStringValue(): Uint8Array | string;
+  getStringValue_asU8(): Uint8Array;
+  getStringValue_asB64(): string;
+  setStringValue(value: Uint8Array | string): void;
 
-    hasNegativeIntValue(): boolean;
-    clearNegativeIntValue(): void;
-    getNegativeIntValue(): number | undefined;
-    setNegativeIntValue(value: number): void;
+  hasAggregateValue(): boolean;
+  clearAggregateValue(): void;
+  getAggregateValue(): string | undefined;
+  setAggregateValue(value: string): void;
 
-
-    hasDoubleValue(): boolean;
-    clearDoubleValue(): void;
-    getDoubleValue(): number | undefined;
-    setDoubleValue(value: number): void;
-
-
-    hasStringValue(): boolean;
-    clearStringValue(): void;
-    getStringValue(): Uint8Array | string;
-    getStringValue_asU8(): Uint8Array;
-    getStringValue_asB64(): string;
-    setStringValue(value: Uint8Array | string): void;
-
-
-    hasAggregateValue(): boolean;
-    clearAggregateValue(): void;
-    getAggregateValue(): string | undefined;
-    setAggregateValue(value: string): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): UninterpretedOption.AsObject;
-    static toObject(includeInstance: boolean, msg: UninterpretedOption): UninterpretedOption.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: UninterpretedOption, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): UninterpretedOption;
-    static deserializeBinaryFromReader(message: UninterpretedOption, reader: jspb.BinaryReader): UninterpretedOption;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UninterpretedOption.AsObject;
+  static toObject(includeInstance: boolean, msg: UninterpretedOption): UninterpretedOption.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UninterpretedOption, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UninterpretedOption;
+  static deserializeBinaryFromReader(message: UninterpretedOption, reader: jspb.BinaryReader): UninterpretedOption;
 }
 
 export namespace UninterpretedOption {
-    export type AsObject = {
-        nameList: Array<UninterpretedOption.NamePart.AsObject>,
-        identifierValue?: string,
-        positiveIntValue?: number,
-        negativeIntValue?: number,
-        doubleValue?: number,
-        stringValue: Uint8Array | string,
-        aggregateValue?: string,
-    }
+  export type AsObject = {
+    nameList: Array<UninterpretedOption.NamePart.AsObject>,
+    identifierValue?: string,
+    positiveIntValue?: number,
+    negativeIntValue?: number,
+    doubleValue?: number,
+    stringValue: Uint8Array | string,
+    aggregateValue?: string,
+  }
 
-
-    export class NamePart extends jspb.Message { 
-
+  export class NamePart extends jspb.Message {
     hasNamePart(): boolean;
     clearNamePart(): void;
     getNamePart(): string | undefined;
     setNamePart(value: string): void;
-
 
     hasIsExtension(): boolean;
     clearIsExtension(): void;
     getIsExtension(): boolean | undefined;
     setIsExtension(value: boolean): void;
 
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): NamePart.AsObject;
-        static toObject(includeInstance: boolean, msg: NamePart): NamePart.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: NamePart, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): NamePart;
-        static deserializeBinaryFromReader(message: NamePart, reader: jspb.BinaryReader): NamePart;
-    }
-
-    export namespace NamePart {
-        export type AsObject = {
-        namePart?: string,
-        isExtension?: boolean,
-        }
-    }
-
-}
-
-export class SourceCodeInfo extends jspb.Message { 
-    clearLocationList(): void;
-    getLocationList(): Array<SourceCodeInfo.Location>;
-    setLocationList(value: Array<SourceCodeInfo.Location>): void;
-    addLocation(value?: SourceCodeInfo.Location, index?: number): SourceCodeInfo.Location;
-
-
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SourceCodeInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: SourceCodeInfo): SourceCodeInfo.AsObject;
+    toObject(includeInstance?: boolean): NamePart.AsObject;
+    static toObject(includeInstance: boolean, msg: NamePart): NamePart.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SourceCodeInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SourceCodeInfo;
-    static deserializeBinaryFromReader(message: SourceCodeInfo, reader: jspb.BinaryReader): SourceCodeInfo;
+    static serializeBinaryToWriter(message: NamePart, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): NamePart;
+    static deserializeBinaryFromReader(message: NamePart, reader: jspb.BinaryReader): NamePart;
+  }
+
+  export namespace NamePart {
+    export type AsObject = {
+      namePart?: string,
+      isExtension?: boolean,
+    }
+  }
+}
+
+export class SourceCodeInfo extends jspb.Message {
+  clearLocationList(): void;
+  getLocationList(): Array<SourceCodeInfo.Location>;
+  setLocationList(value: Array<SourceCodeInfo.Location>): void;
+  addLocation(value?: SourceCodeInfo.Location, index?: number): SourceCodeInfo.Location;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SourceCodeInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: SourceCodeInfo): SourceCodeInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SourceCodeInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SourceCodeInfo;
+  static deserializeBinaryFromReader(message: SourceCodeInfo, reader: jspb.BinaryReader): SourceCodeInfo;
 }
 
 export namespace SourceCodeInfo {
-    export type AsObject = {
-        locationList: Array<SourceCodeInfo.Location.AsObject>,
-    }
+  export type AsObject = {
+    locationList: Array<SourceCodeInfo.Location.AsObject>,
+  }
 
-
-    export class Location extends jspb.Message { 
+  export class Location extends jspb.Message {
     clearPathList(): void;
     getPathList(): Array<number>;
     setPathList(value: Array<number>): void;
@@ -1165,12 +1054,10 @@ export namespace SourceCodeInfo {
     setSpanList(value: Array<number>): void;
     addSpan(value: number, index?: number): number;
 
-
     hasLeadingComments(): boolean;
     clearLeadingComments(): void;
     getLeadingComments(): string | undefined;
     setLeadingComments(value: string): void;
-
 
     hasTrailingComments(): boolean;
     clearTrailingComments(): void;
@@ -1182,94 +1069,86 @@ export namespace SourceCodeInfo {
     setLeadingDetachedCommentsList(value: Array<string>): void;
     addLeadingDetachedComments(value: string, index?: number): string;
 
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): Location.AsObject;
-        static toObject(includeInstance: boolean, msg: Location): Location.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: Location, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): Location;
-        static deserializeBinaryFromReader(message: Location, reader: jspb.BinaryReader): Location;
-    }
-
-    export namespace Location {
-        export type AsObject = {
-        pathList: Array<number>,
-        spanList: Array<number>,
-        leadingComments?: string,
-        trailingComments?: string,
-        leadingDetachedCommentsList: Array<string>,
-        }
-    }
-
-}
-
-export class GeneratedCodeInfo extends jspb.Message { 
-    clearAnnotationList(): void;
-    getAnnotationList(): Array<GeneratedCodeInfo.Annotation>;
-    setAnnotationList(value: Array<GeneratedCodeInfo.Annotation>): void;
-    addAnnotation(value?: GeneratedCodeInfo.Annotation, index?: number): GeneratedCodeInfo.Annotation;
-
-
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GeneratedCodeInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: GeneratedCodeInfo): GeneratedCodeInfo.AsObject;
+    toObject(includeInstance?: boolean): Location.AsObject;
+    static toObject(includeInstance: boolean, msg: Location): Location.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GeneratedCodeInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GeneratedCodeInfo;
-    static deserializeBinaryFromReader(message: GeneratedCodeInfo, reader: jspb.BinaryReader): GeneratedCodeInfo;
+    static serializeBinaryToWriter(message: Location, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Location;
+    static deserializeBinaryFromReader(message: Location, reader: jspb.BinaryReader): Location;
+  }
+
+  export namespace Location {
+    export type AsObject = {
+      pathList: Array<number>,
+      spanList: Array<number>,
+      leadingComments?: string,
+      trailingComments?: string,
+      leadingDetachedCommentsList: Array<string>,
+    }
+  }
+}
+
+export class GeneratedCodeInfo extends jspb.Message {
+  clearAnnotationList(): void;
+  getAnnotationList(): Array<GeneratedCodeInfo.Annotation>;
+  setAnnotationList(value: Array<GeneratedCodeInfo.Annotation>): void;
+  addAnnotation(value?: GeneratedCodeInfo.Annotation, index?: number): GeneratedCodeInfo.Annotation;
+
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GeneratedCodeInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: GeneratedCodeInfo): GeneratedCodeInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GeneratedCodeInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GeneratedCodeInfo;
+  static deserializeBinaryFromReader(message: GeneratedCodeInfo, reader: jspb.BinaryReader): GeneratedCodeInfo;
 }
 
 export namespace GeneratedCodeInfo {
-    export type AsObject = {
-        annotationList: Array<GeneratedCodeInfo.Annotation.AsObject>,
-    }
+  export type AsObject = {
+    annotationList: Array<GeneratedCodeInfo.Annotation.AsObject>,
+  }
 
-
-    export class Annotation extends jspb.Message { 
+  export class Annotation extends jspb.Message {
     clearPathList(): void;
     getPathList(): Array<number>;
     setPathList(value: Array<number>): void;
     addPath(value: number, index?: number): number;
-
 
     hasSourceFile(): boolean;
     clearSourceFile(): void;
     getSourceFile(): string | undefined;
     setSourceFile(value: string): void;
 
-
     hasBegin(): boolean;
     clearBegin(): void;
     getBegin(): number | undefined;
     setBegin(value: number): void;
-
 
     hasEnd(): boolean;
     clearEnd(): void;
     getEnd(): number | undefined;
     setEnd(value: number): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): Annotation.AsObject;
+    static toObject(includeInstance: boolean, msg: Annotation): Annotation.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: Annotation, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): Annotation;
+    static deserializeBinaryFromReader(message: Annotation, reader: jspb.BinaryReader): Annotation;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): Annotation.AsObject;
-        static toObject(includeInstance: boolean, msg: Annotation): Annotation.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: Annotation, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): Annotation;
-        static deserializeBinaryFromReader(message: Annotation, reader: jspb.BinaryReader): Annotation;
+  export namespace Annotation {
+    export type AsObject = {
+      pathList: Array<number>,
+      sourceFile?: string,
+      begin?: number,
+      end?: number,
     }
-
-    export namespace Annotation {
-        export type AsObject = {
-        pathList: Array<number>,
-        sourceFile?: string,
-        begin?: number,
-        end?: number,
-        }
-    }
-
+  }
 }
+

--- a/lib/proto/lndrpc_pb.d.ts
+++ b/lib/proto/lndrpc_pb.d.ts
@@ -1,1790 +1,1691 @@
 // package: lnrpc
 // file: lndrpc.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
+import * as google_api_annotations_pb from "./google/api/annotations_pb";
 
-export class GenSeedRequest extends jspb.Message { 
-    getAezeedPassphrase(): Uint8Array | string;
-    getAezeedPassphrase_asU8(): Uint8Array;
-    getAezeedPassphrase_asB64(): string;
-    setAezeedPassphrase(value: Uint8Array | string): void;
+export class GenSeedRequest extends jspb.Message {
+  getAezeedPassphrase(): Uint8Array | string;
+  getAezeedPassphrase_asU8(): Uint8Array;
+  getAezeedPassphrase_asB64(): string;
+  setAezeedPassphrase(value: Uint8Array | string): void;
 
-    getSeedEntropy(): Uint8Array | string;
-    getSeedEntropy_asU8(): Uint8Array;
-    getSeedEntropy_asB64(): string;
-    setSeedEntropy(value: Uint8Array | string): void;
+  getSeedEntropy(): Uint8Array | string;
+  getSeedEntropy_asU8(): Uint8Array;
+  getSeedEntropy_asB64(): string;
+  setSeedEntropy(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GenSeedRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GenSeedRequest): GenSeedRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GenSeedRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GenSeedRequest;
-    static deserializeBinaryFromReader(message: GenSeedRequest, reader: jspb.BinaryReader): GenSeedRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GenSeedRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GenSeedRequest): GenSeedRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GenSeedRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GenSeedRequest;
+  static deserializeBinaryFromReader(message: GenSeedRequest, reader: jspb.BinaryReader): GenSeedRequest;
 }
 
 export namespace GenSeedRequest {
-    export type AsObject = {
-        aezeedPassphrase: Uint8Array | string,
-        seedEntropy: Uint8Array | string,
-    }
+  export type AsObject = {
+    aezeedPassphrase: Uint8Array | string,
+    seedEntropy: Uint8Array | string,
+  }
 }
 
-export class GenSeedResponse extends jspb.Message { 
-    clearCipherSeedMnemonicList(): void;
-    getCipherSeedMnemonicList(): Array<string>;
-    setCipherSeedMnemonicList(value: Array<string>): void;
-    addCipherSeedMnemonic(value: string, index?: number): string;
+export class GenSeedResponse extends jspb.Message {
+  clearCipherSeedMnemonicList(): void;
+  getCipherSeedMnemonicList(): Array<string>;
+  setCipherSeedMnemonicList(value: Array<string>): void;
+  addCipherSeedMnemonic(value: string, index?: number): string;
 
-    getEncipheredSeed(): Uint8Array | string;
-    getEncipheredSeed_asU8(): Uint8Array;
-    getEncipheredSeed_asB64(): string;
-    setEncipheredSeed(value: Uint8Array | string): void;
+  getEncipheredSeed(): Uint8Array | string;
+  getEncipheredSeed_asU8(): Uint8Array;
+  getEncipheredSeed_asB64(): string;
+  setEncipheredSeed(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GenSeedResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GenSeedResponse): GenSeedResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GenSeedResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GenSeedResponse;
-    static deserializeBinaryFromReader(message: GenSeedResponse, reader: jspb.BinaryReader): GenSeedResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GenSeedResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GenSeedResponse): GenSeedResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GenSeedResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GenSeedResponse;
+  static deserializeBinaryFromReader(message: GenSeedResponse, reader: jspb.BinaryReader): GenSeedResponse;
 }
 
 export namespace GenSeedResponse {
-    export type AsObject = {
-        cipherSeedMnemonicList: Array<string>,
-        encipheredSeed: Uint8Array | string,
-    }
+  export type AsObject = {
+    cipherSeedMnemonicList: Array<string>,
+    encipheredSeed: Uint8Array | string,
+  }
 }
 
-export class InitWalletRequest extends jspb.Message { 
-    getWalletPassword(): Uint8Array | string;
-    getWalletPassword_asU8(): Uint8Array;
-    getWalletPassword_asB64(): string;
-    setWalletPassword(value: Uint8Array | string): void;
+export class InitWalletRequest extends jspb.Message {
+  getWalletPassword(): Uint8Array | string;
+  getWalletPassword_asU8(): Uint8Array;
+  getWalletPassword_asB64(): string;
+  setWalletPassword(value: Uint8Array | string): void;
 
-    clearCipherSeedMnemonicList(): void;
-    getCipherSeedMnemonicList(): Array<string>;
-    setCipherSeedMnemonicList(value: Array<string>): void;
-    addCipherSeedMnemonic(value: string, index?: number): string;
+  clearCipherSeedMnemonicList(): void;
+  getCipherSeedMnemonicList(): Array<string>;
+  setCipherSeedMnemonicList(value: Array<string>): void;
+  addCipherSeedMnemonic(value: string, index?: number): string;
 
-    getAezeedPassphrase(): Uint8Array | string;
-    getAezeedPassphrase_asU8(): Uint8Array;
-    getAezeedPassphrase_asB64(): string;
-    setAezeedPassphrase(value: Uint8Array | string): void;
+  getAezeedPassphrase(): Uint8Array | string;
+  getAezeedPassphrase_asU8(): Uint8Array;
+  getAezeedPassphrase_asB64(): string;
+  setAezeedPassphrase(value: Uint8Array | string): void;
 
-    getRecoveryWindow(): number;
-    setRecoveryWindow(value: number): void;
+  getRecoveryWindow(): number;
+  setRecoveryWindow(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): InitWalletRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: InitWalletRequest): InitWalletRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: InitWalletRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): InitWalletRequest;
-    static deserializeBinaryFromReader(message: InitWalletRequest, reader: jspb.BinaryReader): InitWalletRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): InitWalletRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: InitWalletRequest): InitWalletRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: InitWalletRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): InitWalletRequest;
+  static deserializeBinaryFromReader(message: InitWalletRequest, reader: jspb.BinaryReader): InitWalletRequest;
 }
 
 export namespace InitWalletRequest {
-    export type AsObject = {
-        walletPassword: Uint8Array | string,
-        cipherSeedMnemonicList: Array<string>,
-        aezeedPassphrase: Uint8Array | string,
-        recoveryWindow: number,
-    }
+  export type AsObject = {
+    walletPassword: Uint8Array | string,
+    cipherSeedMnemonicList: Array<string>,
+    aezeedPassphrase: Uint8Array | string,
+    recoveryWindow: number,
+  }
 }
 
-export class InitWalletResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): InitWalletResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: InitWalletResponse): InitWalletResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: InitWalletResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): InitWalletResponse;
-    static deserializeBinaryFromReader(message: InitWalletResponse, reader: jspb.BinaryReader): InitWalletResponse;
+export class InitWalletResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): InitWalletResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: InitWalletResponse): InitWalletResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: InitWalletResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): InitWalletResponse;
+  static deserializeBinaryFromReader(message: InitWalletResponse, reader: jspb.BinaryReader): InitWalletResponse;
 }
 
 export namespace InitWalletResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class UnlockWalletRequest extends jspb.Message { 
-    getWalletPassword(): Uint8Array | string;
-    getWalletPassword_asU8(): Uint8Array;
-    getWalletPassword_asB64(): string;
-    setWalletPassword(value: Uint8Array | string): void;
+export class UnlockWalletRequest extends jspb.Message {
+  getWalletPassword(): Uint8Array | string;
+  getWalletPassword_asU8(): Uint8Array;
+  getWalletPassword_asB64(): string;
+  setWalletPassword(value: Uint8Array | string): void;
 
-    getRecoveryWindow(): number;
-    setRecoveryWindow(value: number): void;
+  getRecoveryWindow(): number;
+  setRecoveryWindow(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): UnlockWalletRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: UnlockWalletRequest): UnlockWalletRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: UnlockWalletRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): UnlockWalletRequest;
-    static deserializeBinaryFromReader(message: UnlockWalletRequest, reader: jspb.BinaryReader): UnlockWalletRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UnlockWalletRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: UnlockWalletRequest): UnlockWalletRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UnlockWalletRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UnlockWalletRequest;
+  static deserializeBinaryFromReader(message: UnlockWalletRequest, reader: jspb.BinaryReader): UnlockWalletRequest;
 }
 
 export namespace UnlockWalletRequest {
-    export type AsObject = {
-        walletPassword: Uint8Array | string,
-        recoveryWindow: number,
-    }
+  export type AsObject = {
+    walletPassword: Uint8Array | string,
+    recoveryWindow: number,
+  }
 }
 
-export class UnlockWalletResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): UnlockWalletResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: UnlockWalletResponse): UnlockWalletResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: UnlockWalletResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): UnlockWalletResponse;
-    static deserializeBinaryFromReader(message: UnlockWalletResponse, reader: jspb.BinaryReader): UnlockWalletResponse;
+export class UnlockWalletResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): UnlockWalletResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: UnlockWalletResponse): UnlockWalletResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: UnlockWalletResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): UnlockWalletResponse;
+  static deserializeBinaryFromReader(message: UnlockWalletResponse, reader: jspb.BinaryReader): UnlockWalletResponse;
 }
 
 export namespace UnlockWalletResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ChangePasswordRequest extends jspb.Message { 
-    getCurrentPassword(): Uint8Array | string;
-    getCurrentPassword_asU8(): Uint8Array;
-    getCurrentPassword_asB64(): string;
-    setCurrentPassword(value: Uint8Array | string): void;
+export class ChangePasswordRequest extends jspb.Message {
+  getCurrentPassword(): Uint8Array | string;
+  getCurrentPassword_asU8(): Uint8Array;
+  getCurrentPassword_asB64(): string;
+  setCurrentPassword(value: Uint8Array | string): void;
 
-    getNewPassword(): Uint8Array | string;
-    getNewPassword_asU8(): Uint8Array;
-    getNewPassword_asB64(): string;
-    setNewPassword(value: Uint8Array | string): void;
+  getNewPassword(): Uint8Array | string;
+  getNewPassword_asU8(): Uint8Array;
+  getNewPassword_asB64(): string;
+  setNewPassword(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChangePasswordRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ChangePasswordRequest): ChangePasswordRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChangePasswordRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChangePasswordRequest;
-    static deserializeBinaryFromReader(message: ChangePasswordRequest, reader: jspb.BinaryReader): ChangePasswordRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChangePasswordRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ChangePasswordRequest): ChangePasswordRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChangePasswordRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChangePasswordRequest;
+  static deserializeBinaryFromReader(message: ChangePasswordRequest, reader: jspb.BinaryReader): ChangePasswordRequest;
 }
 
 export namespace ChangePasswordRequest {
-    export type AsObject = {
-        currentPassword: Uint8Array | string,
-        newPassword: Uint8Array | string,
-    }
+  export type AsObject = {
+    currentPassword: Uint8Array | string,
+    newPassword: Uint8Array | string,
+  }
 }
 
-export class ChangePasswordResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChangePasswordResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ChangePasswordResponse): ChangePasswordResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChangePasswordResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChangePasswordResponse;
-    static deserializeBinaryFromReader(message: ChangePasswordResponse, reader: jspb.BinaryReader): ChangePasswordResponse;
+export class ChangePasswordResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChangePasswordResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ChangePasswordResponse): ChangePasswordResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChangePasswordResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChangePasswordResponse;
+  static deserializeBinaryFromReader(message: ChangePasswordResponse, reader: jspb.BinaryReader): ChangePasswordResponse;
 }
 
 export namespace ChangePasswordResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class Transaction extends jspb.Message { 
-    getTxHash(): string;
-    setTxHash(value: string): void;
+export class Transaction extends jspb.Message {
+  getTxHash(): string;
+  setTxHash(value: string): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-    getNumConfirmations(): number;
-    setNumConfirmations(value: number): void;
+  getNumConfirmations(): number;
+  setNumConfirmations(value: number): void;
 
-    getBlockHash(): string;
-    setBlockHash(value: string): void;
+  getBlockHash(): string;
+  setBlockHash(value: string): void;
 
-    getBlockHeight(): number;
-    setBlockHeight(value: number): void;
+  getBlockHeight(): number;
+  setBlockHeight(value: number): void;
 
-    getTimeStamp(): number;
-    setTimeStamp(value: number): void;
+  getTimeStamp(): number;
+  setTimeStamp(value: number): void;
 
-    getTotalFees(): number;
-    setTotalFees(value: number): void;
+  getTotalFees(): number;
+  setTotalFees(value: number): void;
 
-    clearDestAddressesList(): void;
-    getDestAddressesList(): Array<string>;
-    setDestAddressesList(value: Array<string>): void;
-    addDestAddresses(value: string, index?: number): string;
+  clearDestAddressesList(): void;
+  getDestAddressesList(): Array<string>;
+  setDestAddressesList(value: Array<string>): void;
+  addDestAddresses(value: string, index?: number): string;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Transaction.AsObject;
-    static toObject(includeInstance: boolean, msg: Transaction): Transaction.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Transaction, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Transaction;
-    static deserializeBinaryFromReader(message: Transaction, reader: jspb.BinaryReader): Transaction;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Transaction.AsObject;
+  static toObject(includeInstance: boolean, msg: Transaction): Transaction.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Transaction, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Transaction;
+  static deserializeBinaryFromReader(message: Transaction, reader: jspb.BinaryReader): Transaction;
 }
 
 export namespace Transaction {
-    export type AsObject = {
-        txHash: string,
-        amount: number,
-        numConfirmations: number,
-        blockHash: string,
-        blockHeight: number,
-        timeStamp: number,
-        totalFees: number,
-        destAddressesList: Array<string>,
-    }
+  export type AsObject = {
+    txHash: string,
+    amount: number,
+    numConfirmations: number,
+    blockHash: string,
+    blockHeight: number,
+    timeStamp: number,
+    totalFees: number,
+    destAddressesList: Array<string>,
+  }
 }
 
-export class GetTransactionsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetTransactionsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetTransactionsRequest): GetTransactionsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetTransactionsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetTransactionsRequest;
-    static deserializeBinaryFromReader(message: GetTransactionsRequest, reader: jspb.BinaryReader): GetTransactionsRequest;
+export class GetTransactionsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetTransactionsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetTransactionsRequest): GetTransactionsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetTransactionsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetTransactionsRequest;
+  static deserializeBinaryFromReader(message: GetTransactionsRequest, reader: jspb.BinaryReader): GetTransactionsRequest;
 }
 
 export namespace GetTransactionsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class TransactionDetails extends jspb.Message { 
-    clearTransactionsList(): void;
-    getTransactionsList(): Array<Transaction>;
-    setTransactionsList(value: Array<Transaction>): void;
-    addTransactions(value?: Transaction, index?: number): Transaction;
+export class TransactionDetails extends jspb.Message {
+  clearTransactionsList(): void;
+  getTransactionsList(): Array<Transaction>;
+  setTransactionsList(value: Array<Transaction>): void;
+  addTransactions(value?: Transaction, index?: number): Transaction;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): TransactionDetails.AsObject;
-    static toObject(includeInstance: boolean, msg: TransactionDetails): TransactionDetails.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: TransactionDetails, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): TransactionDetails;
-    static deserializeBinaryFromReader(message: TransactionDetails, reader: jspb.BinaryReader): TransactionDetails;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): TransactionDetails.AsObject;
+  static toObject(includeInstance: boolean, msg: TransactionDetails): TransactionDetails.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: TransactionDetails, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): TransactionDetails;
+  static deserializeBinaryFromReader(message: TransactionDetails, reader: jspb.BinaryReader): TransactionDetails;
 }
 
 export namespace TransactionDetails {
-    export type AsObject = {
-        transactionsList: Array<Transaction.AsObject>,
-    }
+  export type AsObject = {
+    transactionsList: Array<Transaction.AsObject>,
+  }
 }
 
-export class FeeLimit extends jspb.Message { 
+export class FeeLimit extends jspb.Message {
+  hasFixed(): boolean;
+  clearFixed(): void;
+  getFixed(): number;
+  setFixed(value: number): void;
 
-    hasFixed(): boolean;
-    clearFixed(): void;
-    getFixed(): number;
-    setFixed(value: number): void;
+  hasPercent(): boolean;
+  clearPercent(): void;
+  getPercent(): number;
+  setPercent(value: number): void;
 
-
-    hasPercent(): boolean;
-    clearPercent(): void;
-    getPercent(): number;
-    setPercent(value: number): void;
-
-
-    getLimitCase(): FeeLimit.LimitCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FeeLimit.AsObject;
-    static toObject(includeInstance: boolean, msg: FeeLimit): FeeLimit.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FeeLimit, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FeeLimit;
-    static deserializeBinaryFromReader(message: FeeLimit, reader: jspb.BinaryReader): FeeLimit;
+  getLimitCase(): FeeLimit.LimitCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FeeLimit.AsObject;
+  static toObject(includeInstance: boolean, msg: FeeLimit): FeeLimit.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FeeLimit, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FeeLimit;
+  static deserializeBinaryFromReader(message: FeeLimit, reader: jspb.BinaryReader): FeeLimit;
 }
 
 export namespace FeeLimit {
-    export type AsObject = {
-        fixed: number,
-        percent: number,
-    }
+  export type AsObject = {
+    fixed: number,
+    percent: number,
+  }
 
-    export enum LimitCase {
-        LIMIT_NOT_SET = 0,
-    
+  export enum LimitCase {
+    LIMIT_NOT_SET = 0,
     FIXED = 1,
-
     PERCENT = 2,
-
-    }
-
+  }
 }
 
-export class SendRequest extends jspb.Message { 
-    getDest(): Uint8Array | string;
-    getDest_asU8(): Uint8Array;
-    getDest_asB64(): string;
-    setDest(value: Uint8Array | string): void;
+export class SendRequest extends jspb.Message {
+  getDest(): Uint8Array | string;
+  getDest_asU8(): Uint8Array;
+  getDest_asB64(): string;
+  setDest(value: Uint8Array | string): void;
 
-    getDestString(): string;
-    setDestString(value: string): void;
+  getDestString(): string;
+  setDestString(value: string): void;
 
-    getAmt(): number;
-    setAmt(value: number): void;
+  getAmt(): number;
+  setAmt(value: number): void;
 
-    getPaymentHash(): Uint8Array | string;
-    getPaymentHash_asU8(): Uint8Array;
-    getPaymentHash_asB64(): string;
-    setPaymentHash(value: Uint8Array | string): void;
+  getPaymentHash(): Uint8Array | string;
+  getPaymentHash_asU8(): Uint8Array;
+  getPaymentHash_asB64(): string;
+  setPaymentHash(value: Uint8Array | string): void;
 
-    getPaymentHashString(): string;
-    setPaymentHashString(value: string): void;
+  getPaymentHashString(): string;
+  setPaymentHashString(value: string): void;
 
-    getPaymentRequest(): string;
-    setPaymentRequest(value: string): void;
+  getPaymentRequest(): string;
+  setPaymentRequest(value: string): void;
 
-    getFinalCltvDelta(): number;
-    setFinalCltvDelta(value: number): void;
+  getFinalCltvDelta(): number;
+  setFinalCltvDelta(value: number): void;
 
+  hasFeeLimit(): boolean;
+  clearFeeLimit(): void;
+  getFeeLimit(): FeeLimit | undefined;
+  setFeeLimit(value?: FeeLimit): void;
 
-    hasFeeLimit(): boolean;
-    clearFeeLimit(): void;
-    getFeeLimit(): FeeLimit | undefined;
-    setFeeLimit(value?: FeeLimit): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SendRequest): SendRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendRequest;
-    static deserializeBinaryFromReader(message: SendRequest, reader: jspb.BinaryReader): SendRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SendRequest): SendRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendRequest;
+  static deserializeBinaryFromReader(message: SendRequest, reader: jspb.BinaryReader): SendRequest;
 }
 
 export namespace SendRequest {
-    export type AsObject = {
-        dest: Uint8Array | string,
-        destString: string,
-        amt: number,
-        paymentHash: Uint8Array | string,
-        paymentHashString: string,
-        paymentRequest: string,
-        finalCltvDelta: number,
-        feeLimit?: FeeLimit.AsObject,
-    }
+  export type AsObject = {
+    dest: Uint8Array | string,
+    destString: string,
+    amt: number,
+    paymentHash: Uint8Array | string,
+    paymentHashString: string,
+    paymentRequest: string,
+    finalCltvDelta: number,
+    feeLimit?: FeeLimit.AsObject,
+  }
 }
 
-export class SendResponse extends jspb.Message { 
-    getPaymentError(): string;
-    setPaymentError(value: string): void;
+export class SendResponse extends jspb.Message {
+  getPaymentError(): string;
+  setPaymentError(value: string): void;
 
-    getPaymentPreimage(): Uint8Array | string;
-    getPaymentPreimage_asU8(): Uint8Array;
-    getPaymentPreimage_asB64(): string;
-    setPaymentPreimage(value: Uint8Array | string): void;
+  getPaymentPreimage(): Uint8Array | string;
+  getPaymentPreimage_asU8(): Uint8Array;
+  getPaymentPreimage_asB64(): string;
+  setPaymentPreimage(value: Uint8Array | string): void;
 
+  hasPaymentRoute(): boolean;
+  clearPaymentRoute(): void;
+  getPaymentRoute(): Route | undefined;
+  setPaymentRoute(value?: Route): void;
 
-    hasPaymentRoute(): boolean;
-    clearPaymentRoute(): void;
-    getPaymentRoute(): Route | undefined;
-    setPaymentRoute(value?: Route): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SendResponse): SendResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendResponse;
-    static deserializeBinaryFromReader(message: SendResponse, reader: jspb.BinaryReader): SendResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SendResponse): SendResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendResponse;
+  static deserializeBinaryFromReader(message: SendResponse, reader: jspb.BinaryReader): SendResponse;
 }
 
 export namespace SendResponse {
-    export type AsObject = {
-        paymentError: string,
-        paymentPreimage: Uint8Array | string,
-        paymentRoute?: Route.AsObject,
-    }
+  export type AsObject = {
+    paymentError: string,
+    paymentPreimage: Uint8Array | string,
+    paymentRoute?: Route.AsObject,
+  }
 }
 
-export class SendToRouteRequest extends jspb.Message { 
-    getPaymentHash(): Uint8Array | string;
-    getPaymentHash_asU8(): Uint8Array;
-    getPaymentHash_asB64(): string;
-    setPaymentHash(value: Uint8Array | string): void;
+export class SendToRouteRequest extends jspb.Message {
+  getPaymentHash(): Uint8Array | string;
+  getPaymentHash_asU8(): Uint8Array;
+  getPaymentHash_asB64(): string;
+  setPaymentHash(value: Uint8Array | string): void;
 
-    getPaymentHashString(): string;
-    setPaymentHashString(value: string): void;
+  getPaymentHashString(): string;
+  setPaymentHashString(value: string): void;
 
-    clearRoutesList(): void;
-    getRoutesList(): Array<Route>;
-    setRoutesList(value: Array<Route>): void;
-    addRoutes(value?: Route, index?: number): Route;
+  clearRoutesList(): void;
+  getRoutesList(): Array<Route>;
+  setRoutesList(value: Array<Route>): void;
+  addRoutes(value?: Route, index?: number): Route;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendToRouteRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SendToRouteRequest): SendToRouteRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendToRouteRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendToRouteRequest;
-    static deserializeBinaryFromReader(message: SendToRouteRequest, reader: jspb.BinaryReader): SendToRouteRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendToRouteRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SendToRouteRequest): SendToRouteRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendToRouteRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendToRouteRequest;
+  static deserializeBinaryFromReader(message: SendToRouteRequest, reader: jspb.BinaryReader): SendToRouteRequest;
 }
 
 export namespace SendToRouteRequest {
-    export type AsObject = {
-        paymentHash: Uint8Array | string,
-        paymentHashString: string,
-        routesList: Array<Route.AsObject>,
-    }
+  export type AsObject = {
+    paymentHash: Uint8Array | string,
+    paymentHashString: string,
+    routesList: Array<Route.AsObject>,
+  }
 }
 
-export class ChannelPoint extends jspb.Message { 
+export class ChannelPoint extends jspb.Message {
+  hasFundingTxidBytes(): boolean;
+  clearFundingTxidBytes(): void;
+  getFundingTxidBytes(): Uint8Array | string;
+  getFundingTxidBytes_asU8(): Uint8Array;
+  getFundingTxidBytes_asB64(): string;
+  setFundingTxidBytes(value: Uint8Array | string): void;
 
-    hasFundingTxidBytes(): boolean;
-    clearFundingTxidBytes(): void;
-    getFundingTxidBytes(): Uint8Array | string;
-    getFundingTxidBytes_asU8(): Uint8Array;
-    getFundingTxidBytes_asB64(): string;
-    setFundingTxidBytes(value: Uint8Array | string): void;
+  hasFundingTxidStr(): boolean;
+  clearFundingTxidStr(): void;
+  getFundingTxidStr(): string;
+  setFundingTxidStr(value: string): void;
 
+  getOutputIndex(): number;
+  setOutputIndex(value: number): void;
 
-    hasFundingTxidStr(): boolean;
-    clearFundingTxidStr(): void;
-    getFundingTxidStr(): string;
-    setFundingTxidStr(value: string): void;
-
-    getOutputIndex(): number;
-    setOutputIndex(value: number): void;
-
-
-    getFundingTxidCase(): ChannelPoint.FundingTxidCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelPoint.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelPoint): ChannelPoint.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelPoint, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelPoint;
-    static deserializeBinaryFromReader(message: ChannelPoint, reader: jspb.BinaryReader): ChannelPoint;
+  getFunding_txidCase(): ChannelPoint.Funding_txidCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelPoint.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelPoint): ChannelPoint.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelPoint, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelPoint;
+  static deserializeBinaryFromReader(message: ChannelPoint, reader: jspb.BinaryReader): ChannelPoint;
 }
 
 export namespace ChannelPoint {
-    export type AsObject = {
-        fundingTxidBytes: Uint8Array | string,
-        fundingTxidStr: string,
-        outputIndex: number,
-    }
+  export type AsObject = {
+    fundingTxidBytes: Uint8Array | string,
+    fundingTxidStr: string,
+    outputIndex: number,
+  }
 
-    export enum FundingTxidCase {
-        FUNDINGTXID_NOT_SET = 0,
-    
+  export enum Funding_txidCase {
+    FUNDING_TXID_NOT_SET = 0,
     FUNDING_TXID_BYTES = 1,
-
     FUNDING_TXID_STR = 2,
-
-    }
-
+  }
 }
 
-export class LightningAddress extends jspb.Message { 
-    getPubkey(): string;
-    setPubkey(value: string): void;
+export class LightningAddress extends jspb.Message {
+  getPubkey(): string;
+  setPubkey(value: string): void;
 
-    getHost(): string;
-    setHost(value: string): void;
+  getHost(): string;
+  setHost(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LightningAddress.AsObject;
-    static toObject(includeInstance: boolean, msg: LightningAddress): LightningAddress.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LightningAddress, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LightningAddress;
-    static deserializeBinaryFromReader(message: LightningAddress, reader: jspb.BinaryReader): LightningAddress;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): LightningAddress.AsObject;
+  static toObject(includeInstance: boolean, msg: LightningAddress): LightningAddress.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: LightningAddress, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): LightningAddress;
+  static deserializeBinaryFromReader(message: LightningAddress, reader: jspb.BinaryReader): LightningAddress;
 }
 
 export namespace LightningAddress {
-    export type AsObject = {
-        pubkey: string,
-        host: string,
-    }
+  export type AsObject = {
+    pubkey: string,
+    host: string,
+  }
 }
 
-export class SendManyRequest extends jspb.Message { 
+export class SendManyRequest extends jspb.Message {
+  getAddrtoamountMap(): jspb.Map<string, number>;
+  clearAddrtoamountMap(): void;
+  getTargetConf(): number;
+  setTargetConf(value: number): void;
 
-    getAddrtoamountMap(): jspb.Map<string, number>;
-    clearAddrtoamountMap(): void;
+  getSatPerByte(): number;
+  setSatPerByte(value: number): void;
 
-    getTargetConf(): number;
-    setTargetConf(value: number): void;
-
-    getSatPerByte(): number;
-    setSatPerByte(value: number): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendManyRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SendManyRequest): SendManyRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendManyRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendManyRequest;
-    static deserializeBinaryFromReader(message: SendManyRequest, reader: jspb.BinaryReader): SendManyRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendManyRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SendManyRequest): SendManyRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendManyRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendManyRequest;
+  static deserializeBinaryFromReader(message: SendManyRequest, reader: jspb.BinaryReader): SendManyRequest;
 }
 
 export namespace SendManyRequest {
-    export type AsObject = {
-
-        addrtoamountMap: Array<[string, number]>,
-        targetConf: number,
-        satPerByte: number,
-    }
+  export type AsObject = {
+    addrtoamountMap: Array<[string, number]>,
+    targetConf: number,
+    satPerByte: number,
+  }
 }
 
-export class SendManyResponse extends jspb.Message { 
-    getTxid(): string;
-    setTxid(value: string): void;
+export class SendManyResponse extends jspb.Message {
+  getTxid(): string;
+  setTxid(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendManyResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SendManyResponse): SendManyResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendManyResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendManyResponse;
-    static deserializeBinaryFromReader(message: SendManyResponse, reader: jspb.BinaryReader): SendManyResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendManyResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SendManyResponse): SendManyResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendManyResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendManyResponse;
+  static deserializeBinaryFromReader(message: SendManyResponse, reader: jspb.BinaryReader): SendManyResponse;
 }
 
 export namespace SendManyResponse {
-    export type AsObject = {
-        txid: string,
-    }
+  export type AsObject = {
+    txid: string,
+  }
 }
 
-export class SendCoinsRequest extends jspb.Message { 
-    getAddr(): string;
-    setAddr(value: string): void;
+export class SendCoinsRequest extends jspb.Message {
+  getAddr(): string;
+  setAddr(value: string): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-    getTargetConf(): number;
-    setTargetConf(value: number): void;
+  getTargetConf(): number;
+  setTargetConf(value: number): void;
 
-    getSatPerByte(): number;
-    setSatPerByte(value: number): void;
+  getSatPerByte(): number;
+  setSatPerByte(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendCoinsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SendCoinsRequest): SendCoinsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendCoinsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendCoinsRequest;
-    static deserializeBinaryFromReader(message: SendCoinsRequest, reader: jspb.BinaryReader): SendCoinsRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendCoinsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SendCoinsRequest): SendCoinsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendCoinsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendCoinsRequest;
+  static deserializeBinaryFromReader(message: SendCoinsRequest, reader: jspb.BinaryReader): SendCoinsRequest;
 }
 
 export namespace SendCoinsRequest {
-    export type AsObject = {
-        addr: string,
-        amount: number,
-        targetConf: number,
-        satPerByte: number,
-    }
+  export type AsObject = {
+    addr: string,
+    amount: number,
+    targetConf: number,
+    satPerByte: number,
+  }
 }
 
-export class SendCoinsResponse extends jspb.Message { 
-    getTxid(): string;
-    setTxid(value: string): void;
+export class SendCoinsResponse extends jspb.Message {
+  getTxid(): string;
+  setTxid(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SendCoinsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SendCoinsResponse): SendCoinsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SendCoinsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SendCoinsResponse;
-    static deserializeBinaryFromReader(message: SendCoinsResponse, reader: jspb.BinaryReader): SendCoinsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SendCoinsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SendCoinsResponse): SendCoinsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SendCoinsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SendCoinsResponse;
+  static deserializeBinaryFromReader(message: SendCoinsResponse, reader: jspb.BinaryReader): SendCoinsResponse;
 }
 
 export namespace SendCoinsResponse {
-    export type AsObject = {
-        txid: string,
-    }
+  export type AsObject = {
+    txid: string,
+  }
 }
 
-export class NewAddressRequest extends jspb.Message { 
-    getType(): NewAddressRequest.AddressType;
-    setType(value: NewAddressRequest.AddressType): void;
+export class NewAddressRequest extends jspb.Message {
+  getType(): NewAddressRequest.AddressType;
+  setType(value: NewAddressRequest.AddressType): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NewAddressRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: NewAddressRequest): NewAddressRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NewAddressRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NewAddressRequest;
-    static deserializeBinaryFromReader(message: NewAddressRequest, reader: jspb.BinaryReader): NewAddressRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NewAddressRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: NewAddressRequest): NewAddressRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NewAddressRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NewAddressRequest;
+  static deserializeBinaryFromReader(message: NewAddressRequest, reader: jspb.BinaryReader): NewAddressRequest;
 }
 
 export namespace NewAddressRequest {
-    export type AsObject = {
-        type: NewAddressRequest.AddressType,
-    }
+  export type AsObject = {
+    type: NewAddressRequest.AddressType,
+  }
 
-    export enum AddressType {
+  export enum AddressType {
     WITNESS_PUBKEY_HASH = 0,
     NESTED_PUBKEY_HASH = 1,
-    }
-
+  }
 }
 
-export class NewWitnessAddressRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NewWitnessAddressRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: NewWitnessAddressRequest): NewWitnessAddressRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NewWitnessAddressRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NewWitnessAddressRequest;
-    static deserializeBinaryFromReader(message: NewWitnessAddressRequest, reader: jspb.BinaryReader): NewWitnessAddressRequest;
+export class NewWitnessAddressRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NewWitnessAddressRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: NewWitnessAddressRequest): NewWitnessAddressRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NewWitnessAddressRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NewWitnessAddressRequest;
+  static deserializeBinaryFromReader(message: NewWitnessAddressRequest, reader: jspb.BinaryReader): NewWitnessAddressRequest;
 }
 
 export namespace NewWitnessAddressRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class NewAddressResponse extends jspb.Message { 
-    getAddress(): string;
-    setAddress(value: string): void;
+export class NewAddressResponse extends jspb.Message {
+  getAddress(): string;
+  setAddress(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NewAddressResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: NewAddressResponse): NewAddressResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NewAddressResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NewAddressResponse;
-    static deserializeBinaryFromReader(message: NewAddressResponse, reader: jspb.BinaryReader): NewAddressResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NewAddressResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: NewAddressResponse): NewAddressResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NewAddressResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NewAddressResponse;
+  static deserializeBinaryFromReader(message: NewAddressResponse, reader: jspb.BinaryReader): NewAddressResponse;
 }
 
 export namespace NewAddressResponse {
-    export type AsObject = {
-        address: string,
-    }
+  export type AsObject = {
+    address: string,
+  }
 }
 
-export class SignMessageRequest extends jspb.Message { 
-    getMsg(): Uint8Array | string;
-    getMsg_asU8(): Uint8Array;
-    getMsg_asB64(): string;
-    setMsg(value: Uint8Array | string): void;
+export class SignMessageRequest extends jspb.Message {
+  getMsg(): Uint8Array | string;
+  getMsg_asU8(): Uint8Array;
+  getMsg_asB64(): string;
+  setMsg(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SignMessageRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: SignMessageRequest): SignMessageRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SignMessageRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SignMessageRequest;
-    static deserializeBinaryFromReader(message: SignMessageRequest, reader: jspb.BinaryReader): SignMessageRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SignMessageRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: SignMessageRequest): SignMessageRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SignMessageRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SignMessageRequest;
+  static deserializeBinaryFromReader(message: SignMessageRequest, reader: jspb.BinaryReader): SignMessageRequest;
 }
 
 export namespace SignMessageRequest {
-    export type AsObject = {
-        msg: Uint8Array | string,
-    }
+  export type AsObject = {
+    msg: Uint8Array | string,
+  }
 }
 
-export class SignMessageResponse extends jspb.Message { 
-    getSignature(): string;
-    setSignature(value: string): void;
+export class SignMessageResponse extends jspb.Message {
+  getSignature(): string;
+  setSignature(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): SignMessageResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: SignMessageResponse): SignMessageResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: SignMessageResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): SignMessageResponse;
-    static deserializeBinaryFromReader(message: SignMessageResponse, reader: jspb.BinaryReader): SignMessageResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): SignMessageResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: SignMessageResponse): SignMessageResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: SignMessageResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): SignMessageResponse;
+  static deserializeBinaryFromReader(message: SignMessageResponse, reader: jspb.BinaryReader): SignMessageResponse;
 }
 
 export namespace SignMessageResponse {
-    export type AsObject = {
-        signature: string,
-    }
+  export type AsObject = {
+    signature: string,
+  }
 }
 
-export class VerifyMessageRequest extends jspb.Message { 
-    getMsg(): Uint8Array | string;
-    getMsg_asU8(): Uint8Array;
-    getMsg_asB64(): string;
-    setMsg(value: Uint8Array | string): void;
+export class VerifyMessageRequest extends jspb.Message {
+  getMsg(): Uint8Array | string;
+  getMsg_asU8(): Uint8Array;
+  getMsg_asB64(): string;
+  setMsg(value: Uint8Array | string): void;
 
-    getSignature(): string;
-    setSignature(value: string): void;
+  getSignature(): string;
+  setSignature(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): VerifyMessageRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: VerifyMessageRequest): VerifyMessageRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: VerifyMessageRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): VerifyMessageRequest;
-    static deserializeBinaryFromReader(message: VerifyMessageRequest, reader: jspb.BinaryReader): VerifyMessageRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): VerifyMessageRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: VerifyMessageRequest): VerifyMessageRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: VerifyMessageRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): VerifyMessageRequest;
+  static deserializeBinaryFromReader(message: VerifyMessageRequest, reader: jspb.BinaryReader): VerifyMessageRequest;
 }
 
 export namespace VerifyMessageRequest {
-    export type AsObject = {
-        msg: Uint8Array | string,
-        signature: string,
-    }
+  export type AsObject = {
+    msg: Uint8Array | string,
+    signature: string,
+  }
 }
 
-export class VerifyMessageResponse extends jspb.Message { 
-    getValid(): boolean;
-    setValid(value: boolean): void;
+export class VerifyMessageResponse extends jspb.Message {
+  getValid(): boolean;
+  setValid(value: boolean): void;
 
-    getPubkey(): string;
-    setPubkey(value: string): void;
+  getPubkey(): string;
+  setPubkey(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): VerifyMessageResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: VerifyMessageResponse): VerifyMessageResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: VerifyMessageResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): VerifyMessageResponse;
-    static deserializeBinaryFromReader(message: VerifyMessageResponse, reader: jspb.BinaryReader): VerifyMessageResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): VerifyMessageResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: VerifyMessageResponse): VerifyMessageResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: VerifyMessageResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): VerifyMessageResponse;
+  static deserializeBinaryFromReader(message: VerifyMessageResponse, reader: jspb.BinaryReader): VerifyMessageResponse;
 }
 
 export namespace VerifyMessageResponse {
-    export type AsObject = {
-        valid: boolean,
-        pubkey: string,
-    }
+  export type AsObject = {
+    valid: boolean,
+    pubkey: string,
+  }
 }
 
-export class ConnectPeerRequest extends jspb.Message { 
+export class ConnectPeerRequest extends jspb.Message {
+  hasAddr(): boolean;
+  clearAddr(): void;
+  getAddr(): LightningAddress | undefined;
+  setAddr(value?: LightningAddress): void;
 
-    hasAddr(): boolean;
-    clearAddr(): void;
-    getAddr(): LightningAddress | undefined;
-    setAddr(value?: LightningAddress): void;
+  getPerm(): boolean;
+  setPerm(value: boolean): void;
 
-    getPerm(): boolean;
-    setPerm(value: boolean): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConnectPeerRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ConnectPeerRequest): ConnectPeerRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConnectPeerRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConnectPeerRequest;
-    static deserializeBinaryFromReader(message: ConnectPeerRequest, reader: jspb.BinaryReader): ConnectPeerRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConnectPeerRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ConnectPeerRequest): ConnectPeerRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConnectPeerRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConnectPeerRequest;
+  static deserializeBinaryFromReader(message: ConnectPeerRequest, reader: jspb.BinaryReader): ConnectPeerRequest;
 }
 
 export namespace ConnectPeerRequest {
-    export type AsObject = {
-        addr?: LightningAddress.AsObject,
-        perm: boolean,
-    }
+  export type AsObject = {
+    addr?: LightningAddress.AsObject,
+    perm: boolean,
+  }
 }
 
-export class ConnectPeerResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConnectPeerResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ConnectPeerResponse): ConnectPeerResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConnectPeerResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConnectPeerResponse;
-    static deserializeBinaryFromReader(message: ConnectPeerResponse, reader: jspb.BinaryReader): ConnectPeerResponse;
+export class ConnectPeerResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConnectPeerResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ConnectPeerResponse): ConnectPeerResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConnectPeerResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConnectPeerResponse;
+  static deserializeBinaryFromReader(message: ConnectPeerResponse, reader: jspb.BinaryReader): ConnectPeerResponse;
 }
 
 export namespace ConnectPeerResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class DisconnectPeerRequest extends jspb.Message { 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+export class DisconnectPeerRequest extends jspb.Message {
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DisconnectPeerRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: DisconnectPeerRequest): DisconnectPeerRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DisconnectPeerRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DisconnectPeerRequest;
-    static deserializeBinaryFromReader(message: DisconnectPeerRequest, reader: jspb.BinaryReader): DisconnectPeerRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DisconnectPeerRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: DisconnectPeerRequest): DisconnectPeerRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DisconnectPeerRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DisconnectPeerRequest;
+  static deserializeBinaryFromReader(message: DisconnectPeerRequest, reader: jspb.BinaryReader): DisconnectPeerRequest;
 }
 
 export namespace DisconnectPeerRequest {
-    export type AsObject = {
-        pubKey: string,
-    }
+  export type AsObject = {
+    pubKey: string,
+  }
 }
 
-export class DisconnectPeerResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DisconnectPeerResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: DisconnectPeerResponse): DisconnectPeerResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DisconnectPeerResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DisconnectPeerResponse;
-    static deserializeBinaryFromReader(message: DisconnectPeerResponse, reader: jspb.BinaryReader): DisconnectPeerResponse;
+export class DisconnectPeerResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DisconnectPeerResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: DisconnectPeerResponse): DisconnectPeerResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DisconnectPeerResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DisconnectPeerResponse;
+  static deserializeBinaryFromReader(message: DisconnectPeerResponse, reader: jspb.BinaryReader): DisconnectPeerResponse;
 }
 
 export namespace DisconnectPeerResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class HTLC extends jspb.Message { 
-    getIncoming(): boolean;
-    setIncoming(value: boolean): void;
+export class HTLC extends jspb.Message {
+  getIncoming(): boolean;
+  setIncoming(value: boolean): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-    getHashLock(): Uint8Array | string;
-    getHashLock_asU8(): Uint8Array;
-    getHashLock_asB64(): string;
-    setHashLock(value: Uint8Array | string): void;
+  getHashLock(): Uint8Array | string;
+  getHashLock_asU8(): Uint8Array;
+  getHashLock_asB64(): string;
+  setHashLock(value: Uint8Array | string): void;
 
-    getExpirationHeight(): number;
-    setExpirationHeight(value: number): void;
+  getExpirationHeight(): number;
+  setExpirationHeight(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): HTLC.AsObject;
-    static toObject(includeInstance: boolean, msg: HTLC): HTLC.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: HTLC, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): HTLC;
-    static deserializeBinaryFromReader(message: HTLC, reader: jspb.BinaryReader): HTLC;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): HTLC.AsObject;
+  static toObject(includeInstance: boolean, msg: HTLC): HTLC.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: HTLC, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): HTLC;
+  static deserializeBinaryFromReader(message: HTLC, reader: jspb.BinaryReader): HTLC;
 }
 
 export namespace HTLC {
-    export type AsObject = {
-        incoming: boolean,
-        amount: number,
-        hashLock: Uint8Array | string,
-        expirationHeight: number,
-    }
+  export type AsObject = {
+    incoming: boolean,
+    amount: number,
+    hashLock: Uint8Array | string,
+    expirationHeight: number,
+  }
 }
 
-export class Channel extends jspb.Message { 
-    getActive(): boolean;
-    setActive(value: boolean): void;
+export class Channel extends jspb.Message {
+  getActive(): boolean;
+  setActive(value: boolean): void;
 
-    getRemotePubkey(): string;
-    setRemotePubkey(value: string): void;
+  getRemotePubkey(): string;
+  setRemotePubkey(value: string): void;
 
-    getChannelPoint(): string;
-    setChannelPoint(value: string): void;
+  getChannelPoint(): string;
+  setChannelPoint(value: string): void;
 
-    getChanId(): number;
-    setChanId(value: number): void;
+  getChanId(): number;
+  setChanId(value: number): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
-    getLocalBalance(): number;
-    setLocalBalance(value: number): void;
+  getLocalBalance(): number;
+  setLocalBalance(value: number): void;
 
-    getRemoteBalance(): number;
-    setRemoteBalance(value: number): void;
+  getRemoteBalance(): number;
+  setRemoteBalance(value: number): void;
 
-    getCommitFee(): number;
-    setCommitFee(value: number): void;
+  getCommitFee(): number;
+  setCommitFee(value: number): void;
 
-    getCommitWeight(): number;
-    setCommitWeight(value: number): void;
+  getCommitWeight(): number;
+  setCommitWeight(value: number): void;
 
-    getFeePerKw(): number;
-    setFeePerKw(value: number): void;
+  getFeePerKw(): number;
+  setFeePerKw(value: number): void;
 
-    getUnsettledBalance(): number;
-    setUnsettledBalance(value: number): void;
+  getUnsettledBalance(): number;
+  setUnsettledBalance(value: number): void;
 
-    getTotalSatoshisSent(): number;
-    setTotalSatoshisSent(value: number): void;
+  getTotalSatoshisSent(): number;
+  setTotalSatoshisSent(value: number): void;
 
-    getTotalSatoshisReceived(): number;
-    setTotalSatoshisReceived(value: number): void;
+  getTotalSatoshisReceived(): number;
+  setTotalSatoshisReceived(value: number): void;
 
-    getNumUpdates(): number;
-    setNumUpdates(value: number): void;
+  getNumUpdates(): number;
+  setNumUpdates(value: number): void;
 
-    clearPendingHtlcsList(): void;
-    getPendingHtlcsList(): Array<HTLC>;
-    setPendingHtlcsList(value: Array<HTLC>): void;
-    addPendingHtlcs(value?: HTLC, index?: number): HTLC;
+  clearPendingHtlcsList(): void;
+  getPendingHtlcsList(): Array<HTLC>;
+  setPendingHtlcsList(value: Array<HTLC>): void;
+  addPendingHtlcs(value?: HTLC, index?: number): HTLC;
 
-    getCsvDelay(): number;
-    setCsvDelay(value: number): void;
+  getCsvDelay(): number;
+  setCsvDelay(value: number): void;
 
-    getPrivate(): boolean;
-    setPrivate(value: boolean): void;
+  getPrivate(): boolean;
+  setPrivate(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Channel.AsObject;
-    static toObject(includeInstance: boolean, msg: Channel): Channel.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Channel, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Channel;
-    static deserializeBinaryFromReader(message: Channel, reader: jspb.BinaryReader): Channel;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Channel.AsObject;
+  static toObject(includeInstance: boolean, msg: Channel): Channel.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Channel, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Channel;
+  static deserializeBinaryFromReader(message: Channel, reader: jspb.BinaryReader): Channel;
 }
 
 export namespace Channel {
-    export type AsObject = {
-        active: boolean,
-        remotePubkey: string,
-        channelPoint: string,
-        chanId: number,
-        capacity: number,
-        localBalance: number,
-        remoteBalance: number,
-        commitFee: number,
-        commitWeight: number,
-        feePerKw: number,
-        unsettledBalance: number,
-        totalSatoshisSent: number,
-        totalSatoshisReceived: number,
-        numUpdates: number,
-        pendingHtlcsList: Array<HTLC.AsObject>,
-        csvDelay: number,
-        pb_private: boolean,
-    }
+  export type AsObject = {
+    active: boolean,
+    remotePubkey: string,
+    channelPoint: string,
+    chanId: number,
+    capacity: number,
+    localBalance: number,
+    remoteBalance: number,
+    commitFee: number,
+    commitWeight: number,
+    feePerKw: number,
+    unsettledBalance: number,
+    totalSatoshisSent: number,
+    totalSatoshisReceived: number,
+    numUpdates: number,
+    pendingHtlcsList: Array<HTLC.AsObject>,
+    csvDelay: number,
+    pb_private: boolean,
+  }
 }
 
-export class ListChannelsRequest extends jspb.Message { 
-    getActiveOnly(): boolean;
-    setActiveOnly(value: boolean): void;
+export class ListChannelsRequest extends jspb.Message {
+  getActiveOnly(): boolean;
+  setActiveOnly(value: boolean): void;
 
-    getInactiveOnly(): boolean;
-    setInactiveOnly(value: boolean): void;
+  getInactiveOnly(): boolean;
+  setInactiveOnly(value: boolean): void;
 
-    getPublicOnly(): boolean;
-    setPublicOnly(value: boolean): void;
+  getPublicOnly(): boolean;
+  setPublicOnly(value: boolean): void;
 
-    getPrivateOnly(): boolean;
-    setPrivateOnly(value: boolean): void;
+  getPrivateOnly(): boolean;
+  setPrivateOnly(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListChannelsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListChannelsRequest): ListChannelsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListChannelsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListChannelsRequest;
-    static deserializeBinaryFromReader(message: ListChannelsRequest, reader: jspb.BinaryReader): ListChannelsRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListChannelsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListChannelsRequest): ListChannelsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListChannelsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListChannelsRequest;
+  static deserializeBinaryFromReader(message: ListChannelsRequest, reader: jspb.BinaryReader): ListChannelsRequest;
 }
 
 export namespace ListChannelsRequest {
-    export type AsObject = {
-        activeOnly: boolean,
-        inactiveOnly: boolean,
-        publicOnly: boolean,
-        privateOnly: boolean,
-    }
+  export type AsObject = {
+    activeOnly: boolean,
+    inactiveOnly: boolean,
+    publicOnly: boolean,
+    privateOnly: boolean,
+  }
 }
 
-export class ListChannelsResponse extends jspb.Message { 
-    clearChannelsList(): void;
-    getChannelsList(): Array<Channel>;
-    setChannelsList(value: Array<Channel>): void;
-    addChannels(value?: Channel, index?: number): Channel;
+export class ListChannelsResponse extends jspb.Message {
+  clearChannelsList(): void;
+  getChannelsList(): Array<Channel>;
+  setChannelsList(value: Array<Channel>): void;
+  addChannels(value?: Channel, index?: number): Channel;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListChannelsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListChannelsResponse): ListChannelsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListChannelsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListChannelsResponse;
-    static deserializeBinaryFromReader(message: ListChannelsResponse, reader: jspb.BinaryReader): ListChannelsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListChannelsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListChannelsResponse): ListChannelsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListChannelsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListChannelsResponse;
+  static deserializeBinaryFromReader(message: ListChannelsResponse, reader: jspb.BinaryReader): ListChannelsResponse;
 }
 
 export namespace ListChannelsResponse {
-    export type AsObject = {
-        channelsList: Array<Channel.AsObject>,
-    }
+  export type AsObject = {
+    channelsList: Array<Channel.AsObject>,
+  }
 }
 
-export class ChannelCloseSummary extends jspb.Message { 
-    getChannelPoint(): string;
-    setChannelPoint(value: string): void;
+export class ChannelCloseSummary extends jspb.Message {
+  getChannelPoint(): string;
+  setChannelPoint(value: string): void;
 
-    getChanId(): number;
-    setChanId(value: number): void;
+  getChanId(): number;
+  setChanId(value: number): void;
 
-    getChainHash(): string;
-    setChainHash(value: string): void;
+  getChainHash(): string;
+  setChainHash(value: string): void;
 
-    getClosingTxHash(): string;
-    setClosingTxHash(value: string): void;
+  getClosingTxHash(): string;
+  setClosingTxHash(value: string): void;
 
-    getRemotePubkey(): string;
-    setRemotePubkey(value: string): void;
+  getRemotePubkey(): string;
+  setRemotePubkey(value: string): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
-    getCloseHeight(): number;
-    setCloseHeight(value: number): void;
+  getCloseHeight(): number;
+  setCloseHeight(value: number): void;
 
-    getSettledBalance(): number;
-    setSettledBalance(value: number): void;
+  getSettledBalance(): number;
+  setSettledBalance(value: number): void;
 
-    getTimeLockedBalance(): number;
-    setTimeLockedBalance(value: number): void;
+  getTimeLockedBalance(): number;
+  setTimeLockedBalance(value: number): void;
 
-    getCloseType(): ChannelCloseSummary.ClosureType;
-    setCloseType(value: ChannelCloseSummary.ClosureType): void;
+  getCloseType(): ChannelCloseSummary.ClosureType;
+  setCloseType(value: ChannelCloseSummary.ClosureType): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelCloseSummary.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelCloseSummary): ChannelCloseSummary.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelCloseSummary, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelCloseSummary;
-    static deserializeBinaryFromReader(message: ChannelCloseSummary, reader: jspb.BinaryReader): ChannelCloseSummary;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelCloseSummary.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelCloseSummary): ChannelCloseSummary.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelCloseSummary, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelCloseSummary;
+  static deserializeBinaryFromReader(message: ChannelCloseSummary, reader: jspb.BinaryReader): ChannelCloseSummary;
 }
 
 export namespace ChannelCloseSummary {
-    export type AsObject = {
-        channelPoint: string,
-        chanId: number,
-        chainHash: string,
-        closingTxHash: string,
-        remotePubkey: string,
-        capacity: number,
-        closeHeight: number,
-        settledBalance: number,
-        timeLockedBalance: number,
-        closeType: ChannelCloseSummary.ClosureType,
-    }
+  export type AsObject = {
+    channelPoint: string,
+    chanId: number,
+    chainHash: string,
+    closingTxHash: string,
+    remotePubkey: string,
+    capacity: number,
+    closeHeight: number,
+    settledBalance: number,
+    timeLockedBalance: number,
+    closeType: ChannelCloseSummary.ClosureType,
+  }
 
-    export enum ClosureType {
+  export enum ClosureType {
     COOPERATIVE_CLOSE = 0,
     LOCAL_FORCE_CLOSE = 1,
     REMOTE_FORCE_CLOSE = 2,
     BREACH_CLOSE = 3,
     FUNDING_CANCELED = 4,
-    }
-
+  }
 }
 
-export class ClosedChannelsRequest extends jspb.Message { 
-    getCooperative(): boolean;
-    setCooperative(value: boolean): void;
+export class ClosedChannelsRequest extends jspb.Message {
+  getCooperative(): boolean;
+  setCooperative(value: boolean): void;
 
-    getLocalForce(): boolean;
-    setLocalForce(value: boolean): void;
+  getLocalForce(): boolean;
+  setLocalForce(value: boolean): void;
 
-    getRemoteForce(): boolean;
-    setRemoteForce(value: boolean): void;
+  getRemoteForce(): boolean;
+  setRemoteForce(value: boolean): void;
 
-    getBreach(): boolean;
-    setBreach(value: boolean): void;
+  getBreach(): boolean;
+  setBreach(value: boolean): void;
 
-    getFundingCanceled(): boolean;
-    setFundingCanceled(value: boolean): void;
+  getFundingCanceled(): boolean;
+  setFundingCanceled(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ClosedChannelsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ClosedChannelsRequest): ClosedChannelsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ClosedChannelsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ClosedChannelsRequest;
-    static deserializeBinaryFromReader(message: ClosedChannelsRequest, reader: jspb.BinaryReader): ClosedChannelsRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ClosedChannelsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ClosedChannelsRequest): ClosedChannelsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ClosedChannelsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ClosedChannelsRequest;
+  static deserializeBinaryFromReader(message: ClosedChannelsRequest, reader: jspb.BinaryReader): ClosedChannelsRequest;
 }
 
 export namespace ClosedChannelsRequest {
-    export type AsObject = {
-        cooperative: boolean,
-        localForce: boolean,
-        remoteForce: boolean,
-        breach: boolean,
-        fundingCanceled: boolean,
-    }
+  export type AsObject = {
+    cooperative: boolean,
+    localForce: boolean,
+    remoteForce: boolean,
+    breach: boolean,
+    fundingCanceled: boolean,
+  }
 }
 
-export class ClosedChannelsResponse extends jspb.Message { 
-    clearChannelsList(): void;
-    getChannelsList(): Array<ChannelCloseSummary>;
-    setChannelsList(value: Array<ChannelCloseSummary>): void;
-    addChannels(value?: ChannelCloseSummary, index?: number): ChannelCloseSummary;
+export class ClosedChannelsResponse extends jspb.Message {
+  clearChannelsList(): void;
+  getChannelsList(): Array<ChannelCloseSummary>;
+  setChannelsList(value: Array<ChannelCloseSummary>): void;
+  addChannels(value?: ChannelCloseSummary, index?: number): ChannelCloseSummary;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ClosedChannelsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ClosedChannelsResponse): ClosedChannelsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ClosedChannelsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ClosedChannelsResponse;
-    static deserializeBinaryFromReader(message: ClosedChannelsResponse, reader: jspb.BinaryReader): ClosedChannelsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ClosedChannelsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ClosedChannelsResponse): ClosedChannelsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ClosedChannelsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ClosedChannelsResponse;
+  static deserializeBinaryFromReader(message: ClosedChannelsResponse, reader: jspb.BinaryReader): ClosedChannelsResponse;
 }
 
 export namespace ClosedChannelsResponse {
-    export type AsObject = {
-        channelsList: Array<ChannelCloseSummary.AsObject>,
-    }
+  export type AsObject = {
+    channelsList: Array<ChannelCloseSummary.AsObject>,
+  }
 }
 
-export class Peer extends jspb.Message { 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+export class Peer extends jspb.Message {
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-    getAddress(): string;
-    setAddress(value: string): void;
+  getAddress(): string;
+  setAddress(value: string): void;
 
-    getBytesSent(): number;
-    setBytesSent(value: number): void;
+  getBytesSent(): number;
+  setBytesSent(value: number): void;
 
-    getBytesRecv(): number;
-    setBytesRecv(value: number): void;
+  getBytesRecv(): number;
+  setBytesRecv(value: number): void;
 
-    getSatSent(): number;
-    setSatSent(value: number): void;
+  getSatSent(): number;
+  setSatSent(value: number): void;
 
-    getSatRecv(): number;
-    setSatRecv(value: number): void;
+  getSatRecv(): number;
+  setSatRecv(value: number): void;
 
-    getInbound(): boolean;
-    setInbound(value: boolean): void;
+  getInbound(): boolean;
+  setInbound(value: boolean): void;
 
-    getPingTime(): number;
-    setPingTime(value: number): void;
+  getPingTime(): number;
+  setPingTime(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Peer.AsObject;
-    static toObject(includeInstance: boolean, msg: Peer): Peer.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Peer, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Peer;
-    static deserializeBinaryFromReader(message: Peer, reader: jspb.BinaryReader): Peer;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Peer.AsObject;
+  static toObject(includeInstance: boolean, msg: Peer): Peer.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Peer, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Peer;
+  static deserializeBinaryFromReader(message: Peer, reader: jspb.BinaryReader): Peer;
 }
 
 export namespace Peer {
-    export type AsObject = {
-        pubKey: string,
-        address: string,
-        bytesSent: number,
-        bytesRecv: number,
-        satSent: number,
-        satRecv: number,
-        inbound: boolean,
-        pingTime: number,
-    }
+  export type AsObject = {
+    pubKey: string,
+    address: string,
+    bytesSent: number,
+    bytesRecv: number,
+    satSent: number,
+    satRecv: number,
+    inbound: boolean,
+    pingTime: number,
+  }
 }
 
-export class ListPeersRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPeersRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPeersRequest): ListPeersRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPeersRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPeersRequest;
-    static deserializeBinaryFromReader(message: ListPeersRequest, reader: jspb.BinaryReader): ListPeersRequest;
+export class ListPeersRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPeersRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPeersRequest): ListPeersRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPeersRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPeersRequest;
+  static deserializeBinaryFromReader(message: ListPeersRequest, reader: jspb.BinaryReader): ListPeersRequest;
 }
 
 export namespace ListPeersRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ListPeersResponse extends jspb.Message { 
-    clearPeersList(): void;
-    getPeersList(): Array<Peer>;
-    setPeersList(value: Array<Peer>): void;
-    addPeers(value?: Peer, index?: number): Peer;
+export class ListPeersResponse extends jspb.Message {
+  clearPeersList(): void;
+  getPeersList(): Array<Peer>;
+  setPeersList(value: Array<Peer>): void;
+  addPeers(value?: Peer, index?: number): Peer;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPeersResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPeersResponse): ListPeersResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPeersResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPeersResponse;
-    static deserializeBinaryFromReader(message: ListPeersResponse, reader: jspb.BinaryReader): ListPeersResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPeersResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPeersResponse): ListPeersResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPeersResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPeersResponse;
+  static deserializeBinaryFromReader(message: ListPeersResponse, reader: jspb.BinaryReader): ListPeersResponse;
 }
 
 export namespace ListPeersResponse {
-    export type AsObject = {
-        peersList: Array<Peer.AsObject>,
-    }
+  export type AsObject = {
+    peersList: Array<Peer.AsObject>,
+  }
 }
 
-export class GetInfoRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
-    static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
+export class GetInfoRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
+  static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
 }
 
 export namespace GetInfoRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GetInfoResponse extends jspb.Message { 
-    getIdentityPubkey(): string;
-    setIdentityPubkey(value: string): void;
+export class GetInfoResponse extends jspb.Message {
+  getIdentityPubkey(): string;
+  setIdentityPubkey(value: string): void;
 
-    getAlias(): string;
-    setAlias(value: string): void;
+  getAlias(): string;
+  setAlias(value: string): void;
 
-    getNumPendingChannels(): number;
-    setNumPendingChannels(value: number): void;
+  getNumPendingChannels(): number;
+  setNumPendingChannels(value: number): void;
 
-    getNumActiveChannels(): number;
-    setNumActiveChannels(value: number): void;
+  getNumActiveChannels(): number;
+  setNumActiveChannels(value: number): void;
 
-    getNumPeers(): number;
-    setNumPeers(value: number): void;
+  getNumPeers(): number;
+  setNumPeers(value: number): void;
 
-    getBlockHeight(): number;
-    setBlockHeight(value: number): void;
+  getBlockHeight(): number;
+  setBlockHeight(value: number): void;
 
-    getBlockHash(): string;
-    setBlockHash(value: string): void;
+  getBlockHash(): string;
+  setBlockHash(value: string): void;
 
-    getSyncedToChain(): boolean;
-    setSyncedToChain(value: boolean): void;
+  getSyncedToChain(): boolean;
+  setSyncedToChain(value: boolean): void;
 
-    getTestnet(): boolean;
-    setTestnet(value: boolean): void;
+  getTestnet(): boolean;
+  setTestnet(value: boolean): void;
 
-    clearChainsList(): void;
-    getChainsList(): Array<string>;
-    setChainsList(value: Array<string>): void;
-    addChains(value: string, index?: number): string;
+  clearChainsList(): void;
+  getChainsList(): Array<string>;
+  setChainsList(value: Array<string>): void;
+  addChains(value: string, index?: number): string;
 
-    clearUrisList(): void;
-    getUrisList(): Array<string>;
-    setUrisList(value: Array<string>): void;
-    addUris(value: string, index?: number): string;
+  clearUrisList(): void;
+  getUrisList(): Array<string>;
+  setUrisList(value: Array<string>): void;
+  addUris(value: string, index?: number): string;
 
-    getBestHeaderTimestamp(): number;
-    setBestHeaderTimestamp(value: number): void;
+  getBestHeaderTimestamp(): number;
+  setBestHeaderTimestamp(value: number): void;
 
-    getVersion(): string;
-    setVersion(value: string): void;
+  getVersion(): string;
+  setVersion(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
-    static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
+  static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
 }
 
 export namespace GetInfoResponse {
-    export type AsObject = {
-        identityPubkey: string,
-        alias: string,
-        numPendingChannels: number,
-        numActiveChannels: number,
-        numPeers: number,
-        blockHeight: number,
-        blockHash: string,
-        syncedToChain: boolean,
-        testnet: boolean,
-        chainsList: Array<string>,
-        urisList: Array<string>,
-        bestHeaderTimestamp: number,
-        version: string,
-    }
+  export type AsObject = {
+    identityPubkey: string,
+    alias: string,
+    numPendingChannels: number,
+    numActiveChannels: number,
+    numPeers: number,
+    blockHeight: number,
+    blockHash: string,
+    syncedToChain: boolean,
+    testnet: boolean,
+    chainsList: Array<string>,
+    urisList: Array<string>,
+    bestHeaderTimestamp: number,
+    version: string,
+  }
 }
 
-export class ConfirmationUpdate extends jspb.Message { 
-    getBlockSha(): Uint8Array | string;
-    getBlockSha_asU8(): Uint8Array;
-    getBlockSha_asB64(): string;
-    setBlockSha(value: Uint8Array | string): void;
+export class ConfirmationUpdate extends jspb.Message {
+  getBlockSha(): Uint8Array | string;
+  getBlockSha_asU8(): Uint8Array;
+  getBlockSha_asB64(): string;
+  setBlockSha(value: Uint8Array | string): void;
 
-    getBlockHeight(): number;
-    setBlockHeight(value: number): void;
+  getBlockHeight(): number;
+  setBlockHeight(value: number): void;
 
-    getNumConfsLeft(): number;
-    setNumConfsLeft(value: number): void;
+  getNumConfsLeft(): number;
+  setNumConfsLeft(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ConfirmationUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ConfirmationUpdate): ConfirmationUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ConfirmationUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ConfirmationUpdate;
-    static deserializeBinaryFromReader(message: ConfirmationUpdate, reader: jspb.BinaryReader): ConfirmationUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ConfirmationUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ConfirmationUpdate): ConfirmationUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ConfirmationUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ConfirmationUpdate;
+  static deserializeBinaryFromReader(message: ConfirmationUpdate, reader: jspb.BinaryReader): ConfirmationUpdate;
 }
 
 export namespace ConfirmationUpdate {
-    export type AsObject = {
-        blockSha: Uint8Array | string,
-        blockHeight: number,
-        numConfsLeft: number,
-    }
+  export type AsObject = {
+    blockSha: Uint8Array | string,
+    blockHeight: number,
+    numConfsLeft: number,
+  }
 }
 
-export class ChannelOpenUpdate extends jspb.Message { 
+export class ChannelOpenUpdate extends jspb.Message {
+  hasChannelPoint(): boolean;
+  clearChannelPoint(): void;
+  getChannelPoint(): ChannelPoint | undefined;
+  setChannelPoint(value?: ChannelPoint): void;
 
-    hasChannelPoint(): boolean;
-    clearChannelPoint(): void;
-    getChannelPoint(): ChannelPoint | undefined;
-    setChannelPoint(value?: ChannelPoint): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelOpenUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelOpenUpdate): ChannelOpenUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelOpenUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelOpenUpdate;
-    static deserializeBinaryFromReader(message: ChannelOpenUpdate, reader: jspb.BinaryReader): ChannelOpenUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelOpenUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelOpenUpdate): ChannelOpenUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelOpenUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelOpenUpdate;
+  static deserializeBinaryFromReader(message: ChannelOpenUpdate, reader: jspb.BinaryReader): ChannelOpenUpdate;
 }
 
 export namespace ChannelOpenUpdate {
-    export type AsObject = {
-        channelPoint?: ChannelPoint.AsObject,
-    }
+  export type AsObject = {
+    channelPoint?: ChannelPoint.AsObject,
+  }
 }
 
-export class ChannelCloseUpdate extends jspb.Message { 
-    getClosingTxid(): Uint8Array | string;
-    getClosingTxid_asU8(): Uint8Array;
-    getClosingTxid_asB64(): string;
-    setClosingTxid(value: Uint8Array | string): void;
+export class ChannelCloseUpdate extends jspb.Message {
+  getClosingTxid(): Uint8Array | string;
+  getClosingTxid_asU8(): Uint8Array;
+  getClosingTxid_asB64(): string;
+  setClosingTxid(value: Uint8Array | string): void;
 
-    getSuccess(): boolean;
-    setSuccess(value: boolean): void;
+  getSuccess(): boolean;
+  setSuccess(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelCloseUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelCloseUpdate): ChannelCloseUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelCloseUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelCloseUpdate;
-    static deserializeBinaryFromReader(message: ChannelCloseUpdate, reader: jspb.BinaryReader): ChannelCloseUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelCloseUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelCloseUpdate): ChannelCloseUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelCloseUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelCloseUpdate;
+  static deserializeBinaryFromReader(message: ChannelCloseUpdate, reader: jspb.BinaryReader): ChannelCloseUpdate;
 }
 
 export namespace ChannelCloseUpdate {
-    export type AsObject = {
-        closingTxid: Uint8Array | string,
-        success: boolean,
-    }
+  export type AsObject = {
+    closingTxid: Uint8Array | string,
+    success: boolean,
+  }
 }
 
-export class CloseChannelRequest extends jspb.Message { 
+export class CloseChannelRequest extends jspb.Message {
+  hasChannelPoint(): boolean;
+  clearChannelPoint(): void;
+  getChannelPoint(): ChannelPoint | undefined;
+  setChannelPoint(value?: ChannelPoint): void;
 
-    hasChannelPoint(): boolean;
-    clearChannelPoint(): void;
-    getChannelPoint(): ChannelPoint | undefined;
-    setChannelPoint(value?: ChannelPoint): void;
+  getForce(): boolean;
+  setForce(value: boolean): void;
 
-    getForce(): boolean;
-    setForce(value: boolean): void;
+  getTargetConf(): number;
+  setTargetConf(value: number): void;
 
-    getTargetConf(): number;
-    setTargetConf(value: number): void;
+  getSatPerByte(): number;
+  setSatPerByte(value: number): void;
 
-    getSatPerByte(): number;
-    setSatPerByte(value: number): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): CloseChannelRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: CloseChannelRequest): CloseChannelRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: CloseChannelRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): CloseChannelRequest;
-    static deserializeBinaryFromReader(message: CloseChannelRequest, reader: jspb.BinaryReader): CloseChannelRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): CloseChannelRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: CloseChannelRequest): CloseChannelRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CloseChannelRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CloseChannelRequest;
+  static deserializeBinaryFromReader(message: CloseChannelRequest, reader: jspb.BinaryReader): CloseChannelRequest;
 }
 
 export namespace CloseChannelRequest {
-    export type AsObject = {
-        channelPoint?: ChannelPoint.AsObject,
-        force: boolean,
-        targetConf: number,
-        satPerByte: number,
-    }
+  export type AsObject = {
+    channelPoint?: ChannelPoint.AsObject,
+    force: boolean,
+    targetConf: number,
+    satPerByte: number,
+  }
 }
 
-export class CloseStatusUpdate extends jspb.Message { 
+export class CloseStatusUpdate extends jspb.Message {
+  hasClosePending(): boolean;
+  clearClosePending(): void;
+  getClosePending(): PendingUpdate | undefined;
+  setClosePending(value?: PendingUpdate): void;
 
-    hasClosePending(): boolean;
-    clearClosePending(): void;
-    getClosePending(): PendingUpdate | undefined;
-    setClosePending(value?: PendingUpdate): void;
+  hasConfirmation(): boolean;
+  clearConfirmation(): void;
+  getConfirmation(): ConfirmationUpdate | undefined;
+  setConfirmation(value?: ConfirmationUpdate): void;
 
+  hasChanClose(): boolean;
+  clearChanClose(): void;
+  getChanClose(): ChannelCloseUpdate | undefined;
+  setChanClose(value?: ChannelCloseUpdate): void;
 
-    hasConfirmation(): boolean;
-    clearConfirmation(): void;
-    getConfirmation(): ConfirmationUpdate | undefined;
-    setConfirmation(value?: ConfirmationUpdate): void;
-
-
-    hasChanClose(): boolean;
-    clearChanClose(): void;
-    getChanClose(): ChannelCloseUpdate | undefined;
-    setChanClose(value?: ChannelCloseUpdate): void;
-
-
-    getUpdateCase(): CloseStatusUpdate.UpdateCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): CloseStatusUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: CloseStatusUpdate): CloseStatusUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: CloseStatusUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): CloseStatusUpdate;
-    static deserializeBinaryFromReader(message: CloseStatusUpdate, reader: jspb.BinaryReader): CloseStatusUpdate;
+  getUpdateCase(): CloseStatusUpdate.UpdateCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): CloseStatusUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: CloseStatusUpdate): CloseStatusUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: CloseStatusUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): CloseStatusUpdate;
+  static deserializeBinaryFromReader(message: CloseStatusUpdate, reader: jspb.BinaryReader): CloseStatusUpdate;
 }
 
 export namespace CloseStatusUpdate {
-    export type AsObject = {
-        closePending?: PendingUpdate.AsObject,
-        confirmation?: ConfirmationUpdate.AsObject,
-        chanClose?: ChannelCloseUpdate.AsObject,
-    }
+  export type AsObject = {
+    closePending?: PendingUpdate.AsObject,
+    confirmation?: ConfirmationUpdate.AsObject,
+    chanClose?: ChannelCloseUpdate.AsObject,
+  }
 
-    export enum UpdateCase {
-        UPDATE_NOT_SET = 0,
-    
+  export enum UpdateCase {
+    UPDATE_NOT_SET = 0,
     CLOSE_PENDING = 1,
-
     CONFIRMATION = 2,
-
     CHAN_CLOSE = 3,
-
-    }
-
+  }
 }
 
-export class PendingUpdate extends jspb.Message { 
-    getTxid(): Uint8Array | string;
-    getTxid_asU8(): Uint8Array;
-    getTxid_asB64(): string;
-    setTxid(value: Uint8Array | string): void;
+export class PendingUpdate extends jspb.Message {
+  getTxid(): Uint8Array | string;
+  getTxid_asU8(): Uint8Array;
+  getTxid_asB64(): string;
+  setTxid(value: Uint8Array | string): void;
 
-    getOutputIndex(): number;
-    setOutputIndex(value: number): void;
+  getOutputIndex(): number;
+  setOutputIndex(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PendingUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: PendingUpdate): PendingUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PendingUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PendingUpdate;
-    static deserializeBinaryFromReader(message: PendingUpdate, reader: jspb.BinaryReader): PendingUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PendingUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: PendingUpdate): PendingUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PendingUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PendingUpdate;
+  static deserializeBinaryFromReader(message: PendingUpdate, reader: jspb.BinaryReader): PendingUpdate;
 }
 
 export namespace PendingUpdate {
-    export type AsObject = {
-        txid: Uint8Array | string,
-        outputIndex: number,
-    }
+  export type AsObject = {
+    txid: Uint8Array | string,
+    outputIndex: number,
+  }
 }
 
-export class OpenChannelRequest extends jspb.Message { 
-    getNodePubkey(): Uint8Array | string;
-    getNodePubkey_asU8(): Uint8Array;
-    getNodePubkey_asB64(): string;
-    setNodePubkey(value: Uint8Array | string): void;
+export class OpenChannelRequest extends jspb.Message {
+  getNodePubkey(): Uint8Array | string;
+  getNodePubkey_asU8(): Uint8Array;
+  getNodePubkey_asB64(): string;
+  setNodePubkey(value: Uint8Array | string): void;
 
-    getNodePubkeyString(): string;
-    setNodePubkeyString(value: string): void;
+  getNodePubkeyString(): string;
+  setNodePubkeyString(value: string): void;
 
-    getLocalFundingAmount(): number;
-    setLocalFundingAmount(value: number): void;
+  getLocalFundingAmount(): number;
+  setLocalFundingAmount(value: number): void;
 
-    getPushSat(): number;
-    setPushSat(value: number): void;
+  getPushSat(): number;
+  setPushSat(value: number): void;
 
-    getTargetConf(): number;
-    setTargetConf(value: number): void;
+  getTargetConf(): number;
+  setTargetConf(value: number): void;
 
-    getSatPerByte(): number;
-    setSatPerByte(value: number): void;
+  getSatPerByte(): number;
+  setSatPerByte(value: number): void;
 
-    getPrivate(): boolean;
-    setPrivate(value: boolean): void;
+  getPrivate(): boolean;
+  setPrivate(value: boolean): void;
 
-    getMinHtlcMsat(): number;
-    setMinHtlcMsat(value: number): void;
+  getMinHtlcMsat(): number;
+  setMinHtlcMsat(value: number): void;
 
-    getRemoteCsvDelay(): number;
-    setRemoteCsvDelay(value: number): void;
+  getRemoteCsvDelay(): number;
+  setRemoteCsvDelay(value: number): void;
 
-    getMinConfs(): number;
-    setMinConfs(value: number): void;
+  getMinConfs(): number;
+  setMinConfs(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OpenChannelRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: OpenChannelRequest): OpenChannelRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OpenChannelRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OpenChannelRequest;
-    static deserializeBinaryFromReader(message: OpenChannelRequest, reader: jspb.BinaryReader): OpenChannelRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OpenChannelRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: OpenChannelRequest): OpenChannelRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OpenChannelRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OpenChannelRequest;
+  static deserializeBinaryFromReader(message: OpenChannelRequest, reader: jspb.BinaryReader): OpenChannelRequest;
 }
 
 export namespace OpenChannelRequest {
-    export type AsObject = {
-        nodePubkey: Uint8Array | string,
-        nodePubkeyString: string,
-        localFundingAmount: number,
-        pushSat: number,
-        targetConf: number,
-        satPerByte: number,
-        pb_private: boolean,
-        minHtlcMsat: number,
-        remoteCsvDelay: number,
-        minConfs: number,
-    }
+  export type AsObject = {
+    nodePubkey: Uint8Array | string,
+    nodePubkeyString: string,
+    localFundingAmount: number,
+    pushSat: number,
+    targetConf: number,
+    satPerByte: number,
+    pb_private: boolean,
+    minHtlcMsat: number,
+    remoteCsvDelay: number,
+    minConfs: number,
+  }
 }
 
-export class OpenStatusUpdate extends jspb.Message { 
+export class OpenStatusUpdate extends jspb.Message {
+  hasChanPending(): boolean;
+  clearChanPending(): void;
+  getChanPending(): PendingUpdate | undefined;
+  setChanPending(value?: PendingUpdate): void;
 
-    hasChanPending(): boolean;
-    clearChanPending(): void;
-    getChanPending(): PendingUpdate | undefined;
-    setChanPending(value?: PendingUpdate): void;
+  hasConfirmation(): boolean;
+  clearConfirmation(): void;
+  getConfirmation(): ConfirmationUpdate | undefined;
+  setConfirmation(value?: ConfirmationUpdate): void;
 
+  hasChanOpen(): boolean;
+  clearChanOpen(): void;
+  getChanOpen(): ChannelOpenUpdate | undefined;
+  setChanOpen(value?: ChannelOpenUpdate): void;
 
-    hasConfirmation(): boolean;
-    clearConfirmation(): void;
-    getConfirmation(): ConfirmationUpdate | undefined;
-    setConfirmation(value?: ConfirmationUpdate): void;
-
-
-    hasChanOpen(): boolean;
-    clearChanOpen(): void;
-    getChanOpen(): ChannelOpenUpdate | undefined;
-    setChanOpen(value?: ChannelOpenUpdate): void;
-
-
-    getUpdateCase(): OpenStatusUpdate.UpdateCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): OpenStatusUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: OpenStatusUpdate): OpenStatusUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: OpenStatusUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): OpenStatusUpdate;
-    static deserializeBinaryFromReader(message: OpenStatusUpdate, reader: jspb.BinaryReader): OpenStatusUpdate;
+  getUpdateCase(): OpenStatusUpdate.UpdateCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): OpenStatusUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: OpenStatusUpdate): OpenStatusUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: OpenStatusUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): OpenStatusUpdate;
+  static deserializeBinaryFromReader(message: OpenStatusUpdate, reader: jspb.BinaryReader): OpenStatusUpdate;
 }
 
 export namespace OpenStatusUpdate {
-    export type AsObject = {
-        chanPending?: PendingUpdate.AsObject,
-        confirmation?: ConfirmationUpdate.AsObject,
-        chanOpen?: ChannelOpenUpdate.AsObject,
-    }
+  export type AsObject = {
+    chanPending?: PendingUpdate.AsObject,
+    confirmation?: ConfirmationUpdate.AsObject,
+    chanOpen?: ChannelOpenUpdate.AsObject,
+  }
 
-    export enum UpdateCase {
-        UPDATE_NOT_SET = 0,
-    
+  export enum UpdateCase {
+    UPDATE_NOT_SET = 0,
     CHAN_PENDING = 1,
-
     CONFIRMATION = 2,
-
     CHAN_OPEN = 3,
-
-    }
-
+  }
 }
 
-export class PendingHTLC extends jspb.Message { 
-    getIncoming(): boolean;
-    setIncoming(value: boolean): void;
+export class PendingHTLC extends jspb.Message {
+  getIncoming(): boolean;
+  setIncoming(value: boolean): void;
 
-    getAmount(): number;
-    setAmount(value: number): void;
+  getAmount(): number;
+  setAmount(value: number): void;
 
-    getOutpoint(): string;
-    setOutpoint(value: string): void;
+  getOutpoint(): string;
+  setOutpoint(value: string): void;
 
-    getMaturityHeight(): number;
-    setMaturityHeight(value: number): void;
+  getMaturityHeight(): number;
+  setMaturityHeight(value: number): void;
 
-    getBlocksTilMaturity(): number;
-    setBlocksTilMaturity(value: number): void;
+  getBlocksTilMaturity(): number;
+  setBlocksTilMaturity(value: number): void;
 
-    getStage(): number;
-    setStage(value: number): void;
+  getStage(): number;
+  setStage(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PendingHTLC.AsObject;
-    static toObject(includeInstance: boolean, msg: PendingHTLC): PendingHTLC.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PendingHTLC, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PendingHTLC;
-    static deserializeBinaryFromReader(message: PendingHTLC, reader: jspb.BinaryReader): PendingHTLC;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PendingHTLC.AsObject;
+  static toObject(includeInstance: boolean, msg: PendingHTLC): PendingHTLC.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PendingHTLC, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PendingHTLC;
+  static deserializeBinaryFromReader(message: PendingHTLC, reader: jspb.BinaryReader): PendingHTLC;
 }
 
 export namespace PendingHTLC {
-    export type AsObject = {
-        incoming: boolean,
-        amount: number,
-        outpoint: string,
-        maturityHeight: number,
-        blocksTilMaturity: number,
-        stage: number,
-    }
+  export type AsObject = {
+    incoming: boolean,
+    amount: number,
+    outpoint: string,
+    maturityHeight: number,
+    blocksTilMaturity: number,
+    stage: number,
+  }
 }
 
-export class PendingChannelsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PendingChannelsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: PendingChannelsRequest): PendingChannelsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PendingChannelsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PendingChannelsRequest;
-    static deserializeBinaryFromReader(message: PendingChannelsRequest, reader: jspb.BinaryReader): PendingChannelsRequest;
+export class PendingChannelsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PendingChannelsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: PendingChannelsRequest): PendingChannelsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PendingChannelsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PendingChannelsRequest;
+  static deserializeBinaryFromReader(message: PendingChannelsRequest, reader: jspb.BinaryReader): PendingChannelsRequest;
 }
 
 export namespace PendingChannelsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class PendingChannelsResponse extends jspb.Message { 
-    getTotalLimboBalance(): number;
-    setTotalLimboBalance(value: number): void;
+export class PendingChannelsResponse extends jspb.Message {
+  getTotalLimboBalance(): number;
+  setTotalLimboBalance(value: number): void;
 
-    clearPendingOpenChannelsList(): void;
-    getPendingOpenChannelsList(): Array<PendingChannelsResponse.PendingOpenChannel>;
-    setPendingOpenChannelsList(value: Array<PendingChannelsResponse.PendingOpenChannel>): void;
-    addPendingOpenChannels(value?: PendingChannelsResponse.PendingOpenChannel, index?: number): PendingChannelsResponse.PendingOpenChannel;
+  clearPendingOpenChannelsList(): void;
+  getPendingOpenChannelsList(): Array<PendingChannelsResponse.PendingOpenChannel>;
+  setPendingOpenChannelsList(value: Array<PendingChannelsResponse.PendingOpenChannel>): void;
+  addPendingOpenChannels(value?: PendingChannelsResponse.PendingOpenChannel, index?: number): PendingChannelsResponse.PendingOpenChannel;
 
-    clearPendingClosingChannelsList(): void;
-    getPendingClosingChannelsList(): Array<PendingChannelsResponse.ClosedChannel>;
-    setPendingClosingChannelsList(value: Array<PendingChannelsResponse.ClosedChannel>): void;
-    addPendingClosingChannels(value?: PendingChannelsResponse.ClosedChannel, index?: number): PendingChannelsResponse.ClosedChannel;
+  clearPendingClosingChannelsList(): void;
+  getPendingClosingChannelsList(): Array<PendingChannelsResponse.ClosedChannel>;
+  setPendingClosingChannelsList(value: Array<PendingChannelsResponse.ClosedChannel>): void;
+  addPendingClosingChannels(value?: PendingChannelsResponse.ClosedChannel, index?: number): PendingChannelsResponse.ClosedChannel;
 
-    clearPendingForceClosingChannelsList(): void;
-    getPendingForceClosingChannelsList(): Array<PendingChannelsResponse.ForceClosedChannel>;
-    setPendingForceClosingChannelsList(value: Array<PendingChannelsResponse.ForceClosedChannel>): void;
-    addPendingForceClosingChannels(value?: PendingChannelsResponse.ForceClosedChannel, index?: number): PendingChannelsResponse.ForceClosedChannel;
+  clearPendingForceClosingChannelsList(): void;
+  getPendingForceClosingChannelsList(): Array<PendingChannelsResponse.ForceClosedChannel>;
+  setPendingForceClosingChannelsList(value: Array<PendingChannelsResponse.ForceClosedChannel>): void;
+  addPendingForceClosingChannels(value?: PendingChannelsResponse.ForceClosedChannel, index?: number): PendingChannelsResponse.ForceClosedChannel;
 
-    clearWaitingCloseChannelsList(): void;
-    getWaitingCloseChannelsList(): Array<PendingChannelsResponse.WaitingCloseChannel>;
-    setWaitingCloseChannelsList(value: Array<PendingChannelsResponse.WaitingCloseChannel>): void;
-    addWaitingCloseChannels(value?: PendingChannelsResponse.WaitingCloseChannel, index?: number): PendingChannelsResponse.WaitingCloseChannel;
+  clearWaitingCloseChannelsList(): void;
+  getWaitingCloseChannelsList(): Array<PendingChannelsResponse.WaitingCloseChannel>;
+  setWaitingCloseChannelsList(value: Array<PendingChannelsResponse.WaitingCloseChannel>): void;
+  addWaitingCloseChannels(value?: PendingChannelsResponse.WaitingCloseChannel, index?: number): PendingChannelsResponse.WaitingCloseChannel;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PendingChannelsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: PendingChannelsResponse): PendingChannelsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PendingChannelsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PendingChannelsResponse;
-    static deserializeBinaryFromReader(message: PendingChannelsResponse, reader: jspb.BinaryReader): PendingChannelsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PendingChannelsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: PendingChannelsResponse): PendingChannelsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PendingChannelsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PendingChannelsResponse;
+  static deserializeBinaryFromReader(message: PendingChannelsResponse, reader: jspb.BinaryReader): PendingChannelsResponse;
 }
 
 export namespace PendingChannelsResponse {
-    export type AsObject = {
-        totalLimboBalance: number,
-        pendingOpenChannelsList: Array<PendingChannelsResponse.PendingOpenChannel.AsObject>,
-        pendingClosingChannelsList: Array<PendingChannelsResponse.ClosedChannel.AsObject>,
-        pendingForceClosingChannelsList: Array<PendingChannelsResponse.ForceClosedChannel.AsObject>,
-        waitingCloseChannelsList: Array<PendingChannelsResponse.WaitingCloseChannel.AsObject>,
-    }
+  export type AsObject = {
+    totalLimboBalance: number,
+    pendingOpenChannelsList: Array<PendingChannelsResponse.PendingOpenChannel.AsObject>,
+    pendingClosingChannelsList: Array<PendingChannelsResponse.ClosedChannel.AsObject>,
+    pendingForceClosingChannelsList: Array<PendingChannelsResponse.ForceClosedChannel.AsObject>,
+    waitingCloseChannelsList: Array<PendingChannelsResponse.WaitingCloseChannel.AsObject>,
+  }
 
-
-    export class PendingChannel extends jspb.Message { 
+  export class PendingChannel extends jspb.Message {
     getRemoteNodePub(): string;
     setRemoteNodePub(value: string): void;
 
@@ -1800,29 +1701,27 @@ export namespace PendingChannelsResponse {
     getRemoteBalance(): number;
     setRemoteBalance(value: number): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): PendingChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: PendingChannel): PendingChannel.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: PendingChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): PendingChannel;
+    static deserializeBinaryFromReader(message: PendingChannel, reader: jspb.BinaryReader): PendingChannel;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): PendingChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: PendingChannel): PendingChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: PendingChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): PendingChannel;
-        static deserializeBinaryFromReader(message: PendingChannel, reader: jspb.BinaryReader): PendingChannel;
+  export namespace PendingChannel {
+    export type AsObject = {
+      remoteNodePub: string,
+      channelPoint: string,
+      capacity: number,
+      localBalance: number,
+      remoteBalance: number,
     }
+  }
 
-    export namespace PendingChannel {
-        export type AsObject = {
-        remoteNodePub: string,
-        channelPoint: string,
-        capacity: number,
-        localBalance: number,
-        remoteBalance: number,
-        }
-    }
-
-    export class PendingOpenChannel extends jspb.Message { 
-
+  export class PendingOpenChannel extends jspb.Message {
     hasChannel(): boolean;
     clearChannel(): void;
     getChannel(): PendingChannelsResponse.PendingChannel | undefined;
@@ -1840,29 +1739,27 @@ export namespace PendingChannelsResponse {
     getFeePerKw(): number;
     setFeePerKw(value: number): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): PendingOpenChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: PendingOpenChannel): PendingOpenChannel.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: PendingOpenChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): PendingOpenChannel;
+    static deserializeBinaryFromReader(message: PendingOpenChannel, reader: jspb.BinaryReader): PendingOpenChannel;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): PendingOpenChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: PendingOpenChannel): PendingOpenChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: PendingOpenChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): PendingOpenChannel;
-        static deserializeBinaryFromReader(message: PendingOpenChannel, reader: jspb.BinaryReader): PendingOpenChannel;
+  export namespace PendingOpenChannel {
+    export type AsObject = {
+      channel?: PendingChannelsResponse.PendingChannel.AsObject,
+      confirmationHeight: number,
+      commitFee: number,
+      commitWeight: number,
+      feePerKw: number,
     }
+  }
 
-    export namespace PendingOpenChannel {
-        export type AsObject = {
-        channel?: PendingChannelsResponse.PendingChannel.AsObject,
-        confirmationHeight: number,
-        commitFee: number,
-        commitWeight: number,
-        feePerKw: number,
-        }
-    }
-
-    export class WaitingCloseChannel extends jspb.Message { 
-
+  export class WaitingCloseChannel extends jspb.Message {
     hasChannel(): boolean;
     clearChannel(): void;
     getChannel(): PendingChannelsResponse.PendingChannel | undefined;
@@ -1871,26 +1768,24 @@ export namespace PendingChannelsResponse {
     getLimboBalance(): number;
     setLimboBalance(value: number): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): WaitingCloseChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: WaitingCloseChannel): WaitingCloseChannel.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: WaitingCloseChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): WaitingCloseChannel;
+    static deserializeBinaryFromReader(message: WaitingCloseChannel, reader: jspb.BinaryReader): WaitingCloseChannel;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): WaitingCloseChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: WaitingCloseChannel): WaitingCloseChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: WaitingCloseChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): WaitingCloseChannel;
-        static deserializeBinaryFromReader(message: WaitingCloseChannel, reader: jspb.BinaryReader): WaitingCloseChannel;
+  export namespace WaitingCloseChannel {
+    export type AsObject = {
+      channel?: PendingChannelsResponse.PendingChannel.AsObject,
+      limboBalance: number,
     }
+  }
 
-    export namespace WaitingCloseChannel {
-        export type AsObject = {
-        channel?: PendingChannelsResponse.PendingChannel.AsObject,
-        limboBalance: number,
-        }
-    }
-
-    export class ClosedChannel extends jspb.Message { 
-
+  export class ClosedChannel extends jspb.Message {
     hasChannel(): boolean;
     clearChannel(): void;
     getChannel(): PendingChannelsResponse.PendingChannel | undefined;
@@ -1899,26 +1794,24 @@ export namespace PendingChannelsResponse {
     getClosingTxid(): string;
     setClosingTxid(value: string): void;
 
+    serializeBinary(): Uint8Array;
+    toObject(includeInstance?: boolean): ClosedChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: ClosedChannel): ClosedChannel.AsObject;
+    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+    static serializeBinaryToWriter(message: ClosedChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ClosedChannel;
+    static deserializeBinaryFromReader(message: ClosedChannel, reader: jspb.BinaryReader): ClosedChannel;
+  }
 
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): ClosedChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: ClosedChannel): ClosedChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: ClosedChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): ClosedChannel;
-        static deserializeBinaryFromReader(message: ClosedChannel, reader: jspb.BinaryReader): ClosedChannel;
+  export namespace ClosedChannel {
+    export type AsObject = {
+      channel?: PendingChannelsResponse.PendingChannel.AsObject,
+      closingTxid: string,
     }
+  }
 
-    export namespace ClosedChannel {
-        export type AsObject = {
-        channel?: PendingChannelsResponse.PendingChannel.AsObject,
-        closingTxid: string,
-        }
-    }
-
-    export class ForceClosedChannel extends jspb.Message { 
-
+  export class ForceClosedChannel extends jspb.Message {
     hasChannel(): boolean;
     clearChannel(): void;
     getChannel(): PendingChannelsResponse.PendingChannel | undefined;
@@ -1944,1633 +1837,1567 @@ export namespace PendingChannelsResponse {
     setPendingHtlcsList(value: Array<PendingHTLC>): void;
     addPendingHtlcs(value?: PendingHTLC, index?: number): PendingHTLC;
 
-
-        serializeBinary(): Uint8Array;
-        toObject(includeInstance?: boolean): ForceClosedChannel.AsObject;
-        static toObject(includeInstance: boolean, msg: ForceClosedChannel): ForceClosedChannel.AsObject;
-        static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-        static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-        static serializeBinaryToWriter(message: ForceClosedChannel, writer: jspb.BinaryWriter): void;
-        static deserializeBinary(bytes: Uint8Array): ForceClosedChannel;
-        static deserializeBinaryFromReader(message: ForceClosedChannel, reader: jspb.BinaryReader): ForceClosedChannel;
-    }
-
-    export namespace ForceClosedChannel {
-        export type AsObject = {
-        channel?: PendingChannelsResponse.PendingChannel.AsObject,
-        closingTxid: string,
-        limboBalance: number,
-        maturityHeight: number,
-        blocksTilMaturity: number,
-        recoveredBalance: number,
-        pendingHtlcsList: Array<PendingHTLC.AsObject>,
-        }
-    }
-
-}
-
-export class WalletBalanceRequest extends jspb.Message { 
-
     serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): WalletBalanceRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: WalletBalanceRequest): WalletBalanceRequest.AsObject;
+    toObject(includeInstance?: boolean): ForceClosedChannel.AsObject;
+    static toObject(includeInstance: boolean, msg: ForceClosedChannel): ForceClosedChannel.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
     static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: WalletBalanceRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): WalletBalanceRequest;
-    static deserializeBinaryFromReader(message: WalletBalanceRequest, reader: jspb.BinaryReader): WalletBalanceRequest;
+    static serializeBinaryToWriter(message: ForceClosedChannel, writer: jspb.BinaryWriter): void;
+    static deserializeBinary(bytes: Uint8Array): ForceClosedChannel;
+    static deserializeBinaryFromReader(message: ForceClosedChannel, reader: jspb.BinaryReader): ForceClosedChannel;
+  }
+
+  export namespace ForceClosedChannel {
+    export type AsObject = {
+      channel?: PendingChannelsResponse.PendingChannel.AsObject,
+      closingTxid: string,
+      limboBalance: number,
+      maturityHeight: number,
+      blocksTilMaturity: number,
+      recoveredBalance: number,
+      pendingHtlcsList: Array<PendingHTLC.AsObject>,
+    }
+  }
+}
+
+export class WalletBalanceRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): WalletBalanceRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: WalletBalanceRequest): WalletBalanceRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: WalletBalanceRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): WalletBalanceRequest;
+  static deserializeBinaryFromReader(message: WalletBalanceRequest, reader: jspb.BinaryReader): WalletBalanceRequest;
 }
 
 export namespace WalletBalanceRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class WalletBalanceResponse extends jspb.Message { 
-    getTotalBalance(): number;
-    setTotalBalance(value: number): void;
+export class WalletBalanceResponse extends jspb.Message {
+  getTotalBalance(): number;
+  setTotalBalance(value: number): void;
 
-    getConfirmedBalance(): number;
-    setConfirmedBalance(value: number): void;
+  getConfirmedBalance(): number;
+  setConfirmedBalance(value: number): void;
 
-    getUnconfirmedBalance(): number;
-    setUnconfirmedBalance(value: number): void;
+  getUnconfirmedBalance(): number;
+  setUnconfirmedBalance(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): WalletBalanceResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: WalletBalanceResponse): WalletBalanceResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: WalletBalanceResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): WalletBalanceResponse;
-    static deserializeBinaryFromReader(message: WalletBalanceResponse, reader: jspb.BinaryReader): WalletBalanceResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): WalletBalanceResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: WalletBalanceResponse): WalletBalanceResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: WalletBalanceResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): WalletBalanceResponse;
+  static deserializeBinaryFromReader(message: WalletBalanceResponse, reader: jspb.BinaryReader): WalletBalanceResponse;
 }
 
 export namespace WalletBalanceResponse {
-    export type AsObject = {
-        totalBalance: number,
-        confirmedBalance: number,
-        unconfirmedBalance: number,
-    }
+  export type AsObject = {
+    totalBalance: number,
+    confirmedBalance: number,
+    unconfirmedBalance: number,
+  }
 }
 
-export class ChannelBalanceRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelBalanceRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelBalanceRequest): ChannelBalanceRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelBalanceRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelBalanceRequest;
-    static deserializeBinaryFromReader(message: ChannelBalanceRequest, reader: jspb.BinaryReader): ChannelBalanceRequest;
+export class ChannelBalanceRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelBalanceRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelBalanceRequest): ChannelBalanceRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelBalanceRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelBalanceRequest;
+  static deserializeBinaryFromReader(message: ChannelBalanceRequest, reader: jspb.BinaryReader): ChannelBalanceRequest;
 }
 
 export namespace ChannelBalanceRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ChannelBalanceResponse extends jspb.Message { 
-    getBalance(): number;
-    setBalance(value: number): void;
+export class ChannelBalanceResponse extends jspb.Message {
+  getBalance(): number;
+  setBalance(value: number): void;
 
-    getPendingOpenBalance(): number;
-    setPendingOpenBalance(value: number): void;
+  getPendingOpenBalance(): number;
+  setPendingOpenBalance(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelBalanceResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelBalanceResponse): ChannelBalanceResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelBalanceResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelBalanceResponse;
-    static deserializeBinaryFromReader(message: ChannelBalanceResponse, reader: jspb.BinaryReader): ChannelBalanceResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelBalanceResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelBalanceResponse): ChannelBalanceResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelBalanceResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelBalanceResponse;
+  static deserializeBinaryFromReader(message: ChannelBalanceResponse, reader: jspb.BinaryReader): ChannelBalanceResponse;
 }
 
 export namespace ChannelBalanceResponse {
-    export type AsObject = {
-        balance: number,
-        pendingOpenBalance: number,
-    }
+  export type AsObject = {
+    balance: number,
+    pendingOpenBalance: number,
+  }
 }
 
-export class QueryRoutesRequest extends jspb.Message { 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+export class QueryRoutesRequest extends jspb.Message {
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-    getAmt(): number;
-    setAmt(value: number): void;
+  getAmt(): number;
+  setAmt(value: number): void;
 
-    getNumRoutes(): number;
-    setNumRoutes(value: number): void;
+  getNumRoutes(): number;
+  setNumRoutes(value: number): void;
 
-    getFinalCltvDelta(): number;
-    setFinalCltvDelta(value: number): void;
+  getFinalCltvDelta(): number;
+  setFinalCltvDelta(value: number): void;
 
+  hasFeeLimit(): boolean;
+  clearFeeLimit(): void;
+  getFeeLimit(): FeeLimit | undefined;
+  setFeeLimit(value?: FeeLimit): void;
 
-    hasFeeLimit(): boolean;
-    clearFeeLimit(): void;
-    getFeeLimit(): FeeLimit | undefined;
-    setFeeLimit(value?: FeeLimit): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): QueryRoutesRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: QueryRoutesRequest): QueryRoutesRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: QueryRoutesRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): QueryRoutesRequest;
-    static deserializeBinaryFromReader(message: QueryRoutesRequest, reader: jspb.BinaryReader): QueryRoutesRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): QueryRoutesRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: QueryRoutesRequest): QueryRoutesRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: QueryRoutesRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): QueryRoutesRequest;
+  static deserializeBinaryFromReader(message: QueryRoutesRequest, reader: jspb.BinaryReader): QueryRoutesRequest;
 }
 
 export namespace QueryRoutesRequest {
-    export type AsObject = {
-        pubKey: string,
-        amt: number,
-        numRoutes: number,
-        finalCltvDelta: number,
-        feeLimit?: FeeLimit.AsObject,
-    }
+  export type AsObject = {
+    pubKey: string,
+    amt: number,
+    numRoutes: number,
+    finalCltvDelta: number,
+    feeLimit?: FeeLimit.AsObject,
+  }
 }
 
-export class QueryRoutesResponse extends jspb.Message { 
-    clearRoutesList(): void;
-    getRoutesList(): Array<Route>;
-    setRoutesList(value: Array<Route>): void;
-    addRoutes(value?: Route, index?: number): Route;
+export class QueryRoutesResponse extends jspb.Message {
+  clearRoutesList(): void;
+  getRoutesList(): Array<Route>;
+  setRoutesList(value: Array<Route>): void;
+  addRoutes(value?: Route, index?: number): Route;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): QueryRoutesResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: QueryRoutesResponse): QueryRoutesResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: QueryRoutesResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): QueryRoutesResponse;
-    static deserializeBinaryFromReader(message: QueryRoutesResponse, reader: jspb.BinaryReader): QueryRoutesResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): QueryRoutesResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: QueryRoutesResponse): QueryRoutesResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: QueryRoutesResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): QueryRoutesResponse;
+  static deserializeBinaryFromReader(message: QueryRoutesResponse, reader: jspb.BinaryReader): QueryRoutesResponse;
 }
 
 export namespace QueryRoutesResponse {
-    export type AsObject = {
-        routesList: Array<Route.AsObject>,
-    }
+  export type AsObject = {
+    routesList: Array<Route.AsObject>,
+  }
 }
 
-export class Hop extends jspb.Message { 
-    getChanId(): number;
-    setChanId(value: number): void;
+export class Hop extends jspb.Message {
+  getChanId(): number;
+  setChanId(value: number): void;
 
-    getChanCapacity(): number;
-    setChanCapacity(value: number): void;
+  getChanCapacity(): number;
+  setChanCapacity(value: number): void;
 
-    getAmtToForward(): number;
-    setAmtToForward(value: number): void;
+  getAmtToForward(): number;
+  setAmtToForward(value: number): void;
 
-    getFee(): number;
-    setFee(value: number): void;
+  getFee(): number;
+  setFee(value: number): void;
 
-    getExpiry(): number;
-    setExpiry(value: number): void;
+  getExpiry(): number;
+  setExpiry(value: number): void;
 
-    getAmtToForwardMsat(): number;
-    setAmtToForwardMsat(value: number): void;
+  getAmtToForwardMsat(): number;
+  setAmtToForwardMsat(value: number): void;
 
-    getFeeMsat(): number;
-    setFeeMsat(value: number): void;
+  getFeeMsat(): number;
+  setFeeMsat(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Hop.AsObject;
-    static toObject(includeInstance: boolean, msg: Hop): Hop.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Hop, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Hop;
-    static deserializeBinaryFromReader(message: Hop, reader: jspb.BinaryReader): Hop;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Hop.AsObject;
+  static toObject(includeInstance: boolean, msg: Hop): Hop.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Hop, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Hop;
+  static deserializeBinaryFromReader(message: Hop, reader: jspb.BinaryReader): Hop;
 }
 
 export namespace Hop {
-    export type AsObject = {
-        chanId: number,
-        chanCapacity: number,
-        amtToForward: number,
-        fee: number,
-        expiry: number,
-        amtToForwardMsat: number,
-        feeMsat: number,
-    }
+  export type AsObject = {
+    chanId: number,
+    chanCapacity: number,
+    amtToForward: number,
+    fee: number,
+    expiry: number,
+    amtToForwardMsat: number,
+    feeMsat: number,
+  }
 }
 
-export class Route extends jspb.Message { 
-    getTotalTimeLock(): number;
-    setTotalTimeLock(value: number): void;
+export class Route extends jspb.Message {
+  getTotalTimeLock(): number;
+  setTotalTimeLock(value: number): void;
 
-    getTotalFees(): number;
-    setTotalFees(value: number): void;
+  getTotalFees(): number;
+  setTotalFees(value: number): void;
 
-    getTotalAmt(): number;
-    setTotalAmt(value: number): void;
+  getTotalAmt(): number;
+  setTotalAmt(value: number): void;
 
-    clearHopsList(): void;
-    getHopsList(): Array<Hop>;
-    setHopsList(value: Array<Hop>): void;
-    addHops(value?: Hop, index?: number): Hop;
+  clearHopsList(): void;
+  getHopsList(): Array<Hop>;
+  setHopsList(value: Array<Hop>): void;
+  addHops(value?: Hop, index?: number): Hop;
 
-    getTotalFeesMsat(): number;
-    setTotalFeesMsat(value: number): void;
+  getTotalFeesMsat(): number;
+  setTotalFeesMsat(value: number): void;
 
-    getTotalAmtMsat(): number;
-    setTotalAmtMsat(value: number): void;
+  getTotalAmtMsat(): number;
+  setTotalAmtMsat(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Route.AsObject;
-    static toObject(includeInstance: boolean, msg: Route): Route.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Route, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Route;
-    static deserializeBinaryFromReader(message: Route, reader: jspb.BinaryReader): Route;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Route.AsObject;
+  static toObject(includeInstance: boolean, msg: Route): Route.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Route, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Route;
+  static deserializeBinaryFromReader(message: Route, reader: jspb.BinaryReader): Route;
 }
 
 export namespace Route {
-    export type AsObject = {
-        totalTimeLock: number,
-        totalFees: number,
-        totalAmt: number,
-        hopsList: Array<Hop.AsObject>,
-        totalFeesMsat: number,
-        totalAmtMsat: number,
-    }
+  export type AsObject = {
+    totalTimeLock: number,
+    totalFees: number,
+    totalAmt: number,
+    hopsList: Array<Hop.AsObject>,
+    totalFeesMsat: number,
+    totalAmtMsat: number,
+  }
 }
 
-export class NodeInfoRequest extends jspb.Message { 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+export class NodeInfoRequest extends jspb.Message {
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NodeInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: NodeInfoRequest): NodeInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NodeInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NodeInfoRequest;
-    static deserializeBinaryFromReader(message: NodeInfoRequest, reader: jspb.BinaryReader): NodeInfoRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NodeInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: NodeInfoRequest): NodeInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NodeInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NodeInfoRequest;
+  static deserializeBinaryFromReader(message: NodeInfoRequest, reader: jspb.BinaryReader): NodeInfoRequest;
 }
 
 export namespace NodeInfoRequest {
-    export type AsObject = {
-        pubKey: string,
-    }
+  export type AsObject = {
+    pubKey: string,
+  }
 }
 
-export class NodeInfo extends jspb.Message { 
+export class NodeInfo extends jspb.Message {
+  hasNode(): boolean;
+  clearNode(): void;
+  getNode(): LightningNode | undefined;
+  setNode(value?: LightningNode): void;
 
-    hasNode(): boolean;
-    clearNode(): void;
-    getNode(): LightningNode | undefined;
-    setNode(value?: LightningNode): void;
+  getNumChannels(): number;
+  setNumChannels(value: number): void;
 
-    getNumChannels(): number;
-    setNumChannels(value: number): void;
+  getTotalCapacity(): number;
+  setTotalCapacity(value: number): void;
 
-    getTotalCapacity(): number;
-    setTotalCapacity(value: number): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NodeInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: NodeInfo): NodeInfo.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NodeInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NodeInfo;
-    static deserializeBinaryFromReader(message: NodeInfo, reader: jspb.BinaryReader): NodeInfo;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NodeInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: NodeInfo): NodeInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NodeInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NodeInfo;
+  static deserializeBinaryFromReader(message: NodeInfo, reader: jspb.BinaryReader): NodeInfo;
 }
 
 export namespace NodeInfo {
-    export type AsObject = {
-        node?: LightningNode.AsObject,
-        numChannels: number,
-        totalCapacity: number,
-    }
+  export type AsObject = {
+    node?: LightningNode.AsObject,
+    numChannels: number,
+    totalCapacity: number,
+  }
 }
 
-export class LightningNode extends jspb.Message { 
-    getLastUpdate(): number;
-    setLastUpdate(value: number): void;
+export class LightningNode extends jspb.Message {
+  getLastUpdate(): number;
+  setLastUpdate(value: number): void;
 
-    getPubKey(): string;
-    setPubKey(value: string): void;
+  getPubKey(): string;
+  setPubKey(value: string): void;
 
-    getAlias(): string;
-    setAlias(value: string): void;
+  getAlias(): string;
+  setAlias(value: string): void;
 
-    clearAddressesList(): void;
-    getAddressesList(): Array<NodeAddress>;
-    setAddressesList(value: Array<NodeAddress>): void;
-    addAddresses(value?: NodeAddress, index?: number): NodeAddress;
+  clearAddressesList(): void;
+  getAddressesList(): Array<NodeAddress>;
+  setAddressesList(value: Array<NodeAddress>): void;
+  addAddresses(value?: NodeAddress, index?: number): NodeAddress;
 
-    getColor(): string;
-    setColor(value: string): void;
+  getColor(): string;
+  setColor(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): LightningNode.AsObject;
-    static toObject(includeInstance: boolean, msg: LightningNode): LightningNode.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: LightningNode, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): LightningNode;
-    static deserializeBinaryFromReader(message: LightningNode, reader: jspb.BinaryReader): LightningNode;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): LightningNode.AsObject;
+  static toObject(includeInstance: boolean, msg: LightningNode): LightningNode.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: LightningNode, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): LightningNode;
+  static deserializeBinaryFromReader(message: LightningNode, reader: jspb.BinaryReader): LightningNode;
 }
 
 export namespace LightningNode {
-    export type AsObject = {
-        lastUpdate: number,
-        pubKey: string,
-        alias: string,
-        addressesList: Array<NodeAddress.AsObject>,
-        color: string,
-    }
+  export type AsObject = {
+    lastUpdate: number,
+    pubKey: string,
+    alias: string,
+    addressesList: Array<NodeAddress.AsObject>,
+    color: string,
+  }
 }
 
-export class NodeAddress extends jspb.Message { 
-    getNetwork(): string;
-    setNetwork(value: string): void;
+export class NodeAddress extends jspb.Message {
+  getNetwork(): string;
+  setNetwork(value: string): void;
 
-    getAddr(): string;
-    setAddr(value: string): void;
+  getAddr(): string;
+  setAddr(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NodeAddress.AsObject;
-    static toObject(includeInstance: boolean, msg: NodeAddress): NodeAddress.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NodeAddress, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NodeAddress;
-    static deserializeBinaryFromReader(message: NodeAddress, reader: jspb.BinaryReader): NodeAddress;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NodeAddress.AsObject;
+  static toObject(includeInstance: boolean, msg: NodeAddress): NodeAddress.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NodeAddress, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NodeAddress;
+  static deserializeBinaryFromReader(message: NodeAddress, reader: jspb.BinaryReader): NodeAddress;
 }
 
 export namespace NodeAddress {
-    export type AsObject = {
-        network: string,
-        addr: string,
-    }
+  export type AsObject = {
+    network: string,
+    addr: string,
+  }
 }
 
-export class RoutingPolicy extends jspb.Message { 
-    getTimeLockDelta(): number;
-    setTimeLockDelta(value: number): void;
+export class RoutingPolicy extends jspb.Message {
+  getTimeLockDelta(): number;
+  setTimeLockDelta(value: number): void;
 
-    getMinHtlc(): number;
-    setMinHtlc(value: number): void;
+  getMinHtlc(): number;
+  setMinHtlc(value: number): void;
 
-    getFeeBaseMsat(): number;
-    setFeeBaseMsat(value: number): void;
+  getFeeBaseMsat(): number;
+  setFeeBaseMsat(value: number): void;
 
-    getFeeRateMilliMsat(): number;
-    setFeeRateMilliMsat(value: number): void;
+  getFeeRateMilliMsat(): number;
+  setFeeRateMilliMsat(value: number): void;
 
-    getDisabled(): boolean;
-    setDisabled(value: boolean): void;
+  getDisabled(): boolean;
+  setDisabled(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RoutingPolicy.AsObject;
-    static toObject(includeInstance: boolean, msg: RoutingPolicy): RoutingPolicy.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RoutingPolicy, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RoutingPolicy;
-    static deserializeBinaryFromReader(message: RoutingPolicy, reader: jspb.BinaryReader): RoutingPolicy;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RoutingPolicy.AsObject;
+  static toObject(includeInstance: boolean, msg: RoutingPolicy): RoutingPolicy.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RoutingPolicy, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RoutingPolicy;
+  static deserializeBinaryFromReader(message: RoutingPolicy, reader: jspb.BinaryReader): RoutingPolicy;
 }
 
 export namespace RoutingPolicy {
-    export type AsObject = {
-        timeLockDelta: number,
-        minHtlc: number,
-        feeBaseMsat: number,
-        feeRateMilliMsat: number,
-        disabled: boolean,
-    }
+  export type AsObject = {
+    timeLockDelta: number,
+    minHtlc: number,
+    feeBaseMsat: number,
+    feeRateMilliMsat: number,
+    disabled: boolean,
+  }
 }
 
-export class ChannelEdge extends jspb.Message { 
-    getChannelId(): number;
-    setChannelId(value: number): void;
+export class ChannelEdge extends jspb.Message {
+  getChannelId(): number;
+  setChannelId(value: number): void;
 
-    getChanPoint(): string;
-    setChanPoint(value: string): void;
+  getChanPoint(): string;
+  setChanPoint(value: string): void;
 
-    getLastUpdate(): number;
-    setLastUpdate(value: number): void;
+  getLastUpdate(): number;
+  setLastUpdate(value: number): void;
 
-    getNode1Pub(): string;
-    setNode1Pub(value: string): void;
+  getNode1Pub(): string;
+  setNode1Pub(value: string): void;
 
-    getNode2Pub(): string;
-    setNode2Pub(value: string): void;
+  getNode2Pub(): string;
+  setNode2Pub(value: string): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
+  hasNode1Policy(): boolean;
+  clearNode1Policy(): void;
+  getNode1Policy(): RoutingPolicy | undefined;
+  setNode1Policy(value?: RoutingPolicy): void;
 
-    hasNode1Policy(): boolean;
-    clearNode1Policy(): void;
-    getNode1Policy(): RoutingPolicy | undefined;
-    setNode1Policy(value?: RoutingPolicy): void;
+  hasNode2Policy(): boolean;
+  clearNode2Policy(): void;
+  getNode2Policy(): RoutingPolicy | undefined;
+  setNode2Policy(value?: RoutingPolicy): void;
 
-
-    hasNode2Policy(): boolean;
-    clearNode2Policy(): void;
-    getNode2Policy(): RoutingPolicy | undefined;
-    setNode2Policy(value?: RoutingPolicy): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelEdge.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelEdge): ChannelEdge.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelEdge, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelEdge;
-    static deserializeBinaryFromReader(message: ChannelEdge, reader: jspb.BinaryReader): ChannelEdge;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelEdge.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelEdge): ChannelEdge.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelEdge, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelEdge;
+  static deserializeBinaryFromReader(message: ChannelEdge, reader: jspb.BinaryReader): ChannelEdge;
 }
 
 export namespace ChannelEdge {
-    export type AsObject = {
-        channelId: number,
-        chanPoint: string,
-        lastUpdate: number,
-        node1Pub: string,
-        node2Pub: string,
-        capacity: number,
-        node1Policy?: RoutingPolicy.AsObject,
-        node2Policy?: RoutingPolicy.AsObject,
-    }
+  export type AsObject = {
+    channelId: number,
+    chanPoint: string,
+    lastUpdate: number,
+    node1Pub: string,
+    node2Pub: string,
+    capacity: number,
+    node1Policy?: RoutingPolicy.AsObject,
+    node2Policy?: RoutingPolicy.AsObject,
+  }
 }
 
-export class ChannelGraphRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelGraphRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelGraphRequest): ChannelGraphRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelGraphRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelGraphRequest;
-    static deserializeBinaryFromReader(message: ChannelGraphRequest, reader: jspb.BinaryReader): ChannelGraphRequest;
+export class ChannelGraphRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelGraphRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelGraphRequest): ChannelGraphRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelGraphRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelGraphRequest;
+  static deserializeBinaryFromReader(message: ChannelGraphRequest, reader: jspb.BinaryReader): ChannelGraphRequest;
 }
 
 export namespace ChannelGraphRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ChannelGraph extends jspb.Message { 
-    clearNodesList(): void;
-    getNodesList(): Array<LightningNode>;
-    setNodesList(value: Array<LightningNode>): void;
-    addNodes(value?: LightningNode, index?: number): LightningNode;
+export class ChannelGraph extends jspb.Message {
+  clearNodesList(): void;
+  getNodesList(): Array<LightningNode>;
+  setNodesList(value: Array<LightningNode>): void;
+  addNodes(value?: LightningNode, index?: number): LightningNode;
 
-    clearEdgesList(): void;
-    getEdgesList(): Array<ChannelEdge>;
-    setEdgesList(value: Array<ChannelEdge>): void;
-    addEdges(value?: ChannelEdge, index?: number): ChannelEdge;
+  clearEdgesList(): void;
+  getEdgesList(): Array<ChannelEdge>;
+  setEdgesList(value: Array<ChannelEdge>): void;
+  addEdges(value?: ChannelEdge, index?: number): ChannelEdge;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelGraph.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelGraph): ChannelGraph.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelGraph, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelGraph;
-    static deserializeBinaryFromReader(message: ChannelGraph, reader: jspb.BinaryReader): ChannelGraph;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelGraph.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelGraph): ChannelGraph.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelGraph, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelGraph;
+  static deserializeBinaryFromReader(message: ChannelGraph, reader: jspb.BinaryReader): ChannelGraph;
 }
 
 export namespace ChannelGraph {
-    export type AsObject = {
-        nodesList: Array<LightningNode.AsObject>,
-        edgesList: Array<ChannelEdge.AsObject>,
-    }
+  export type AsObject = {
+    nodesList: Array<LightningNode.AsObject>,
+    edgesList: Array<ChannelEdge.AsObject>,
+  }
 }
 
-export class ChanInfoRequest extends jspb.Message { 
-    getChanId(): number;
-    setChanId(value: number): void;
+export class ChanInfoRequest extends jspb.Message {
+  getChanId(): number;
+  setChanId(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChanInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ChanInfoRequest): ChanInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChanInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChanInfoRequest;
-    static deserializeBinaryFromReader(message: ChanInfoRequest, reader: jspb.BinaryReader): ChanInfoRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChanInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ChanInfoRequest): ChanInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChanInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChanInfoRequest;
+  static deserializeBinaryFromReader(message: ChanInfoRequest, reader: jspb.BinaryReader): ChanInfoRequest;
 }
 
 export namespace ChanInfoRequest {
-    export type AsObject = {
-        chanId: number,
-    }
+  export type AsObject = {
+    chanId: number,
+  }
 }
 
-export class NetworkInfoRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NetworkInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: NetworkInfoRequest): NetworkInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NetworkInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NetworkInfoRequest;
-    static deserializeBinaryFromReader(message: NetworkInfoRequest, reader: jspb.BinaryReader): NetworkInfoRequest;
+export class NetworkInfoRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NetworkInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: NetworkInfoRequest): NetworkInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NetworkInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NetworkInfoRequest;
+  static deserializeBinaryFromReader(message: NetworkInfoRequest, reader: jspb.BinaryReader): NetworkInfoRequest;
 }
 
 export namespace NetworkInfoRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class NetworkInfo extends jspb.Message { 
-    getGraphDiameter(): number;
-    setGraphDiameter(value: number): void;
+export class NetworkInfo extends jspb.Message {
+  getGraphDiameter(): number;
+  setGraphDiameter(value: number): void;
 
-    getAvgOutDegree(): number;
-    setAvgOutDegree(value: number): void;
+  getAvgOutDegree(): number;
+  setAvgOutDegree(value: number): void;
 
-    getMaxOutDegree(): number;
-    setMaxOutDegree(value: number): void;
+  getMaxOutDegree(): number;
+  setMaxOutDegree(value: number): void;
 
-    getNumNodes(): number;
-    setNumNodes(value: number): void;
+  getNumNodes(): number;
+  setNumNodes(value: number): void;
 
-    getNumChannels(): number;
-    setNumChannels(value: number): void;
+  getNumChannels(): number;
+  setNumChannels(value: number): void;
 
-    getTotalNetworkCapacity(): number;
-    setTotalNetworkCapacity(value: number): void;
+  getTotalNetworkCapacity(): number;
+  setTotalNetworkCapacity(value: number): void;
 
-    getAvgChannelSize(): number;
-    setAvgChannelSize(value: number): void;
+  getAvgChannelSize(): number;
+  setAvgChannelSize(value: number): void;
 
-    getMinChannelSize(): number;
-    setMinChannelSize(value: number): void;
+  getMinChannelSize(): number;
+  setMinChannelSize(value: number): void;
 
-    getMaxChannelSize(): number;
-    setMaxChannelSize(value: number): void;
+  getMaxChannelSize(): number;
+  setMaxChannelSize(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NetworkInfo.AsObject;
-    static toObject(includeInstance: boolean, msg: NetworkInfo): NetworkInfo.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NetworkInfo, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NetworkInfo;
-    static deserializeBinaryFromReader(message: NetworkInfo, reader: jspb.BinaryReader): NetworkInfo;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NetworkInfo.AsObject;
+  static toObject(includeInstance: boolean, msg: NetworkInfo): NetworkInfo.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NetworkInfo, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NetworkInfo;
+  static deserializeBinaryFromReader(message: NetworkInfo, reader: jspb.BinaryReader): NetworkInfo;
 }
 
 export namespace NetworkInfo {
-    export type AsObject = {
-        graphDiameter: number,
-        avgOutDegree: number,
-        maxOutDegree: number,
-        numNodes: number,
-        numChannels: number,
-        totalNetworkCapacity: number,
-        avgChannelSize: number,
-        minChannelSize: number,
-        maxChannelSize: number,
-    }
+  export type AsObject = {
+    graphDiameter: number,
+    avgOutDegree: number,
+    maxOutDegree: number,
+    numNodes: number,
+    numChannels: number,
+    totalNetworkCapacity: number,
+    avgChannelSize: number,
+    minChannelSize: number,
+    maxChannelSize: number,
+  }
 }
 
-export class StopRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): StopRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: StopRequest): StopRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: StopRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): StopRequest;
-    static deserializeBinaryFromReader(message: StopRequest, reader: jspb.BinaryReader): StopRequest;
+export class StopRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): StopRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: StopRequest): StopRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: StopRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): StopRequest;
+  static deserializeBinaryFromReader(message: StopRequest, reader: jspb.BinaryReader): StopRequest;
 }
 
 export namespace StopRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class StopResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): StopResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: StopResponse): StopResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: StopResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): StopResponse;
-    static deserializeBinaryFromReader(message: StopResponse, reader: jspb.BinaryReader): StopResponse;
+export class StopResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): StopResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: StopResponse): StopResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: StopResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): StopResponse;
+  static deserializeBinaryFromReader(message: StopResponse, reader: jspb.BinaryReader): StopResponse;
 }
 
 export namespace StopResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GraphTopologySubscription extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GraphTopologySubscription.AsObject;
-    static toObject(includeInstance: boolean, msg: GraphTopologySubscription): GraphTopologySubscription.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GraphTopologySubscription, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GraphTopologySubscription;
-    static deserializeBinaryFromReader(message: GraphTopologySubscription, reader: jspb.BinaryReader): GraphTopologySubscription;
+export class GraphTopologySubscription extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GraphTopologySubscription.AsObject;
+  static toObject(includeInstance: boolean, msg: GraphTopologySubscription): GraphTopologySubscription.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GraphTopologySubscription, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GraphTopologySubscription;
+  static deserializeBinaryFromReader(message: GraphTopologySubscription, reader: jspb.BinaryReader): GraphTopologySubscription;
 }
 
 export namespace GraphTopologySubscription {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GraphTopologyUpdate extends jspb.Message { 
-    clearNodeUpdatesList(): void;
-    getNodeUpdatesList(): Array<NodeUpdate>;
-    setNodeUpdatesList(value: Array<NodeUpdate>): void;
-    addNodeUpdates(value?: NodeUpdate, index?: number): NodeUpdate;
+export class GraphTopologyUpdate extends jspb.Message {
+  clearNodeUpdatesList(): void;
+  getNodeUpdatesList(): Array<NodeUpdate>;
+  setNodeUpdatesList(value: Array<NodeUpdate>): void;
+  addNodeUpdates(value?: NodeUpdate, index?: number): NodeUpdate;
 
-    clearChannelUpdatesList(): void;
-    getChannelUpdatesList(): Array<ChannelEdgeUpdate>;
-    setChannelUpdatesList(value: Array<ChannelEdgeUpdate>): void;
-    addChannelUpdates(value?: ChannelEdgeUpdate, index?: number): ChannelEdgeUpdate;
+  clearChannelUpdatesList(): void;
+  getChannelUpdatesList(): Array<ChannelEdgeUpdate>;
+  setChannelUpdatesList(value: Array<ChannelEdgeUpdate>): void;
+  addChannelUpdates(value?: ChannelEdgeUpdate, index?: number): ChannelEdgeUpdate;
 
-    clearClosedChansList(): void;
-    getClosedChansList(): Array<ClosedChannelUpdate>;
-    setClosedChansList(value: Array<ClosedChannelUpdate>): void;
-    addClosedChans(value?: ClosedChannelUpdate, index?: number): ClosedChannelUpdate;
+  clearClosedChansList(): void;
+  getClosedChansList(): Array<ClosedChannelUpdate>;
+  setClosedChansList(value: Array<ClosedChannelUpdate>): void;
+  addClosedChans(value?: ClosedChannelUpdate, index?: number): ClosedChannelUpdate;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GraphTopologyUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: GraphTopologyUpdate): GraphTopologyUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GraphTopologyUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GraphTopologyUpdate;
-    static deserializeBinaryFromReader(message: GraphTopologyUpdate, reader: jspb.BinaryReader): GraphTopologyUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GraphTopologyUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: GraphTopologyUpdate): GraphTopologyUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GraphTopologyUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GraphTopologyUpdate;
+  static deserializeBinaryFromReader(message: GraphTopologyUpdate, reader: jspb.BinaryReader): GraphTopologyUpdate;
 }
 
 export namespace GraphTopologyUpdate {
-    export type AsObject = {
-        nodeUpdatesList: Array<NodeUpdate.AsObject>,
-        channelUpdatesList: Array<ChannelEdgeUpdate.AsObject>,
-        closedChansList: Array<ClosedChannelUpdate.AsObject>,
-    }
+  export type AsObject = {
+    nodeUpdatesList: Array<NodeUpdate.AsObject>,
+    channelUpdatesList: Array<ChannelEdgeUpdate.AsObject>,
+    closedChansList: Array<ClosedChannelUpdate.AsObject>,
+  }
 }
 
-export class NodeUpdate extends jspb.Message { 
-    clearAddressesList(): void;
-    getAddressesList(): Array<string>;
-    setAddressesList(value: Array<string>): void;
-    addAddresses(value: string, index?: number): string;
+export class NodeUpdate extends jspb.Message {
+  clearAddressesList(): void;
+  getAddressesList(): Array<string>;
+  setAddressesList(value: Array<string>): void;
+  addAddresses(value: string, index?: number): string;
 
-    getIdentityKey(): string;
-    setIdentityKey(value: string): void;
+  getIdentityKey(): string;
+  setIdentityKey(value: string): void;
 
-    getGlobalFeatures(): Uint8Array | string;
-    getGlobalFeatures_asU8(): Uint8Array;
-    getGlobalFeatures_asB64(): string;
-    setGlobalFeatures(value: Uint8Array | string): void;
+  getGlobalFeatures(): Uint8Array | string;
+  getGlobalFeatures_asU8(): Uint8Array;
+  getGlobalFeatures_asB64(): string;
+  setGlobalFeatures(value: Uint8Array | string): void;
 
-    getAlias(): string;
-    setAlias(value: string): void;
+  getAlias(): string;
+  setAlias(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): NodeUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: NodeUpdate): NodeUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: NodeUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): NodeUpdate;
-    static deserializeBinaryFromReader(message: NodeUpdate, reader: jspb.BinaryReader): NodeUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): NodeUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: NodeUpdate): NodeUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: NodeUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): NodeUpdate;
+  static deserializeBinaryFromReader(message: NodeUpdate, reader: jspb.BinaryReader): NodeUpdate;
 }
 
 export namespace NodeUpdate {
-    export type AsObject = {
-        addressesList: Array<string>,
-        identityKey: string,
-        globalFeatures: Uint8Array | string,
-        alias: string,
-    }
+  export type AsObject = {
+    addressesList: Array<string>,
+    identityKey: string,
+    globalFeatures: Uint8Array | string,
+    alias: string,
+  }
 }
 
-export class ChannelEdgeUpdate extends jspb.Message { 
-    getChanId(): number;
-    setChanId(value: number): void;
+export class ChannelEdgeUpdate extends jspb.Message {
+  getChanId(): number;
+  setChanId(value: number): void;
 
+  hasChanPoint(): boolean;
+  clearChanPoint(): void;
+  getChanPoint(): ChannelPoint | undefined;
+  setChanPoint(value?: ChannelPoint): void;
 
-    hasChanPoint(): boolean;
-    clearChanPoint(): void;
-    getChanPoint(): ChannelPoint | undefined;
-    setChanPoint(value?: ChannelPoint): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  hasRoutingPolicy(): boolean;
+  clearRoutingPolicy(): void;
+  getRoutingPolicy(): RoutingPolicy | undefined;
+  setRoutingPolicy(value?: RoutingPolicy): void;
 
+  getAdvertisingNode(): string;
+  setAdvertisingNode(value: string): void;
 
-    hasRoutingPolicy(): boolean;
-    clearRoutingPolicy(): void;
-    getRoutingPolicy(): RoutingPolicy | undefined;
-    setRoutingPolicy(value?: RoutingPolicy): void;
+  getConnectingNode(): string;
+  setConnectingNode(value: string): void;
 
-    getAdvertisingNode(): string;
-    setAdvertisingNode(value: string): void;
-
-    getConnectingNode(): string;
-    setConnectingNode(value: string): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelEdgeUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelEdgeUpdate): ChannelEdgeUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelEdgeUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelEdgeUpdate;
-    static deserializeBinaryFromReader(message: ChannelEdgeUpdate, reader: jspb.BinaryReader): ChannelEdgeUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelEdgeUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelEdgeUpdate): ChannelEdgeUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelEdgeUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelEdgeUpdate;
+  static deserializeBinaryFromReader(message: ChannelEdgeUpdate, reader: jspb.BinaryReader): ChannelEdgeUpdate;
 }
 
 export namespace ChannelEdgeUpdate {
-    export type AsObject = {
-        chanId: number,
-        chanPoint?: ChannelPoint.AsObject,
-        capacity: number,
-        routingPolicy?: RoutingPolicy.AsObject,
-        advertisingNode: string,
-        connectingNode: string,
-    }
+  export type AsObject = {
+    chanId: number,
+    chanPoint?: ChannelPoint.AsObject,
+    capacity: number,
+    routingPolicy?: RoutingPolicy.AsObject,
+    advertisingNode: string,
+    connectingNode: string,
+  }
 }
 
-export class ClosedChannelUpdate extends jspb.Message { 
-    getChanId(): number;
-    setChanId(value: number): void;
+export class ClosedChannelUpdate extends jspb.Message {
+  getChanId(): number;
+  setChanId(value: number): void;
 
-    getCapacity(): number;
-    setCapacity(value: number): void;
+  getCapacity(): number;
+  setCapacity(value: number): void;
 
-    getClosedHeight(): number;
-    setClosedHeight(value: number): void;
+  getClosedHeight(): number;
+  setClosedHeight(value: number): void;
 
+  hasChanPoint(): boolean;
+  clearChanPoint(): void;
+  getChanPoint(): ChannelPoint | undefined;
+  setChanPoint(value?: ChannelPoint): void;
 
-    hasChanPoint(): boolean;
-    clearChanPoint(): void;
-    getChanPoint(): ChannelPoint | undefined;
-    setChanPoint(value?: ChannelPoint): void;
-
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ClosedChannelUpdate.AsObject;
-    static toObject(includeInstance: boolean, msg: ClosedChannelUpdate): ClosedChannelUpdate.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ClosedChannelUpdate, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ClosedChannelUpdate;
-    static deserializeBinaryFromReader(message: ClosedChannelUpdate, reader: jspb.BinaryReader): ClosedChannelUpdate;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ClosedChannelUpdate.AsObject;
+  static toObject(includeInstance: boolean, msg: ClosedChannelUpdate): ClosedChannelUpdate.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ClosedChannelUpdate, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ClosedChannelUpdate;
+  static deserializeBinaryFromReader(message: ClosedChannelUpdate, reader: jspb.BinaryReader): ClosedChannelUpdate;
 }
 
 export namespace ClosedChannelUpdate {
-    export type AsObject = {
-        chanId: number,
-        capacity: number,
-        closedHeight: number,
-        chanPoint?: ChannelPoint.AsObject,
-    }
+  export type AsObject = {
+    chanId: number,
+    capacity: number,
+    closedHeight: number,
+    chanPoint?: ChannelPoint.AsObject,
+  }
 }
 
-export class HopHint extends jspb.Message { 
-    getNodeId(): string;
-    setNodeId(value: string): void;
+export class HopHint extends jspb.Message {
+  getNodeId(): string;
+  setNodeId(value: string): void;
 
-    getChanId(): number;
-    setChanId(value: number): void;
+  getChanId(): number;
+  setChanId(value: number): void;
 
-    getFeeBaseMsat(): number;
-    setFeeBaseMsat(value: number): void;
+  getFeeBaseMsat(): number;
+  setFeeBaseMsat(value: number): void;
 
-    getFeeProportionalMillionths(): number;
-    setFeeProportionalMillionths(value: number): void;
+  getFeeProportionalMillionths(): number;
+  setFeeProportionalMillionths(value: number): void;
 
-    getCltvExpiryDelta(): number;
-    setCltvExpiryDelta(value: number): void;
+  getCltvExpiryDelta(): number;
+  setCltvExpiryDelta(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): HopHint.AsObject;
-    static toObject(includeInstance: boolean, msg: HopHint): HopHint.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: HopHint, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): HopHint;
-    static deserializeBinaryFromReader(message: HopHint, reader: jspb.BinaryReader): HopHint;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): HopHint.AsObject;
+  static toObject(includeInstance: boolean, msg: HopHint): HopHint.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: HopHint, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): HopHint;
+  static deserializeBinaryFromReader(message: HopHint, reader: jspb.BinaryReader): HopHint;
 }
 
 export namespace HopHint {
-    export type AsObject = {
-        nodeId: string,
-        chanId: number,
-        feeBaseMsat: number,
-        feeProportionalMillionths: number,
-        cltvExpiryDelta: number,
-    }
+  export type AsObject = {
+    nodeId: string,
+    chanId: number,
+    feeBaseMsat: number,
+    feeProportionalMillionths: number,
+    cltvExpiryDelta: number,
+  }
 }
 
-export class RouteHint extends jspb.Message { 
-    clearHopHintsList(): void;
-    getHopHintsList(): Array<HopHint>;
-    setHopHintsList(value: Array<HopHint>): void;
-    addHopHints(value?: HopHint, index?: number): HopHint;
+export class RouteHint extends jspb.Message {
+  clearHopHintsList(): void;
+  getHopHintsList(): Array<HopHint>;
+  setHopHintsList(value: Array<HopHint>): void;
+  addHopHints(value?: HopHint, index?: number): HopHint;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): RouteHint.AsObject;
-    static toObject(includeInstance: boolean, msg: RouteHint): RouteHint.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: RouteHint, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): RouteHint;
-    static deserializeBinaryFromReader(message: RouteHint, reader: jspb.BinaryReader): RouteHint;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): RouteHint.AsObject;
+  static toObject(includeInstance: boolean, msg: RouteHint): RouteHint.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: RouteHint, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): RouteHint;
+  static deserializeBinaryFromReader(message: RouteHint, reader: jspb.BinaryReader): RouteHint;
 }
 
 export namespace RouteHint {
-    export type AsObject = {
-        hopHintsList: Array<HopHint.AsObject>,
-    }
+  export type AsObject = {
+    hopHintsList: Array<HopHint.AsObject>,
+  }
 }
 
-export class Invoice extends jspb.Message { 
-    getMemo(): string;
-    setMemo(value: string): void;
+export class Invoice extends jspb.Message {
+  getMemo(): string;
+  setMemo(value: string): void;
 
-    getReceipt(): Uint8Array | string;
-    getReceipt_asU8(): Uint8Array;
-    getReceipt_asB64(): string;
-    setReceipt(value: Uint8Array | string): void;
+  getReceipt(): Uint8Array | string;
+  getReceipt_asU8(): Uint8Array;
+  getReceipt_asB64(): string;
+  setReceipt(value: Uint8Array | string): void;
 
-    getRPreimage(): Uint8Array | string;
-    getRPreimage_asU8(): Uint8Array;
-    getRPreimage_asB64(): string;
-    setRPreimage(value: Uint8Array | string): void;
+  getRPreimage(): Uint8Array | string;
+  getRPreimage_asU8(): Uint8Array;
+  getRPreimage_asB64(): string;
+  setRPreimage(value: Uint8Array | string): void;
 
-    getRHash(): Uint8Array | string;
-    getRHash_asU8(): Uint8Array;
-    getRHash_asB64(): string;
-    setRHash(value: Uint8Array | string): void;
+  getRHash(): Uint8Array | string;
+  getRHash_asU8(): Uint8Array;
+  getRHash_asB64(): string;
+  setRHash(value: Uint8Array | string): void;
 
-    getValue(): number;
-    setValue(value: number): void;
+  getValue(): number;
+  setValue(value: number): void;
 
-    getSettled(): boolean;
-    setSettled(value: boolean): void;
+  getSettled(): boolean;
+  setSettled(value: boolean): void;
 
-    getCreationDate(): number;
-    setCreationDate(value: number): void;
+  getCreationDate(): number;
+  setCreationDate(value: number): void;
 
-    getSettleDate(): number;
-    setSettleDate(value: number): void;
+  getSettleDate(): number;
+  setSettleDate(value: number): void;
 
-    getPaymentRequest(): string;
-    setPaymentRequest(value: string): void;
+  getPaymentRequest(): string;
+  setPaymentRequest(value: string): void;
 
-    getDescriptionHash(): Uint8Array | string;
-    getDescriptionHash_asU8(): Uint8Array;
-    getDescriptionHash_asB64(): string;
-    setDescriptionHash(value: Uint8Array | string): void;
+  getDescriptionHash(): Uint8Array | string;
+  getDescriptionHash_asU8(): Uint8Array;
+  getDescriptionHash_asB64(): string;
+  setDescriptionHash(value: Uint8Array | string): void;
 
-    getExpiry(): number;
-    setExpiry(value: number): void;
+  getExpiry(): number;
+  setExpiry(value: number): void;
 
-    getFallbackAddr(): string;
-    setFallbackAddr(value: string): void;
+  getFallbackAddr(): string;
+  setFallbackAddr(value: string): void;
 
-    getCltvExpiry(): number;
-    setCltvExpiry(value: number): void;
+  getCltvExpiry(): number;
+  setCltvExpiry(value: number): void;
 
-    clearRouteHintsList(): void;
-    getRouteHintsList(): Array<RouteHint>;
-    setRouteHintsList(value: Array<RouteHint>): void;
-    addRouteHints(value?: RouteHint, index?: number): RouteHint;
+  clearRouteHintsList(): void;
+  getRouteHintsList(): Array<RouteHint>;
+  setRouteHintsList(value: Array<RouteHint>): void;
+  addRouteHints(value?: RouteHint, index?: number): RouteHint;
 
-    getPrivate(): boolean;
-    setPrivate(value: boolean): void;
+  getPrivate(): boolean;
+  setPrivate(value: boolean): void;
 
-    getAddIndex(): number;
-    setAddIndex(value: number): void;
+  getAddIndex(): number;
+  setAddIndex(value: number): void;
 
-    getSettleIndex(): number;
-    setSettleIndex(value: number): void;
+  getSettleIndex(): number;
+  setSettleIndex(value: number): void;
 
-    getAmtPaid(): number;
-    setAmtPaid(value: number): void;
+  getAmtPaid(): number;
+  setAmtPaid(value: number): void;
 
-    getAmtPaidSat(): number;
-    setAmtPaidSat(value: number): void;
+  getAmtPaidSat(): number;
+  setAmtPaidSat(value: number): void;
 
-    getAmtPaidMsat(): number;
-    setAmtPaidMsat(value: number): void;
+  getAmtPaidMsat(): number;
+  setAmtPaidMsat(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Invoice.AsObject;
-    static toObject(includeInstance: boolean, msg: Invoice): Invoice.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Invoice, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Invoice;
-    static deserializeBinaryFromReader(message: Invoice, reader: jspb.BinaryReader): Invoice;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Invoice.AsObject;
+  static toObject(includeInstance: boolean, msg: Invoice): Invoice.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Invoice, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Invoice;
+  static deserializeBinaryFromReader(message: Invoice, reader: jspb.BinaryReader): Invoice;
 }
 
 export namespace Invoice {
-    export type AsObject = {
-        memo: string,
-        receipt: Uint8Array | string,
-        rPreimage: Uint8Array | string,
-        rHash: Uint8Array | string,
-        value: number,
-        settled: boolean,
-        creationDate: number,
-        settleDate: number,
-        paymentRequest: string,
-        descriptionHash: Uint8Array | string,
-        expiry: number,
-        fallbackAddr: string,
-        cltvExpiry: number,
-        routeHintsList: Array<RouteHint.AsObject>,
-        pb_private: boolean,
-        addIndex: number,
-        settleIndex: number,
-        amtPaid: number,
-        amtPaidSat: number,
-        amtPaidMsat: number,
-    }
+  export type AsObject = {
+    memo: string,
+    receipt: Uint8Array | string,
+    rPreimage: Uint8Array | string,
+    rHash: Uint8Array | string,
+    value: number,
+    settled: boolean,
+    creationDate: number,
+    settleDate: number,
+    paymentRequest: string,
+    descriptionHash: Uint8Array | string,
+    expiry: number,
+    fallbackAddr: string,
+    cltvExpiry: number,
+    routeHintsList: Array<RouteHint.AsObject>,
+    pb_private: boolean,
+    addIndex: number,
+    settleIndex: number,
+    amtPaid: number,
+    amtPaidSat: number,
+    amtPaidMsat: number,
+  }
 }
 
-export class AddInvoiceResponse extends jspb.Message { 
-    getRHash(): Uint8Array | string;
-    getRHash_asU8(): Uint8Array;
-    getRHash_asB64(): string;
-    setRHash(value: Uint8Array | string): void;
+export class AddInvoiceResponse extends jspb.Message {
+  getRHash(): Uint8Array | string;
+  getRHash_asU8(): Uint8Array;
+  getRHash_asB64(): string;
+  setRHash(value: Uint8Array | string): void;
 
-    getPaymentRequest(): string;
-    setPaymentRequest(value: string): void;
+  getPaymentRequest(): string;
+  setPaymentRequest(value: string): void;
 
-    getAddIndex(): number;
-    setAddIndex(value: number): void;
+  getAddIndex(): number;
+  setAddIndex(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): AddInvoiceResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: AddInvoiceResponse): AddInvoiceResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: AddInvoiceResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): AddInvoiceResponse;
-    static deserializeBinaryFromReader(message: AddInvoiceResponse, reader: jspb.BinaryReader): AddInvoiceResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): AddInvoiceResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: AddInvoiceResponse): AddInvoiceResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: AddInvoiceResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): AddInvoiceResponse;
+  static deserializeBinaryFromReader(message: AddInvoiceResponse, reader: jspb.BinaryReader): AddInvoiceResponse;
 }
 
 export namespace AddInvoiceResponse {
-    export type AsObject = {
-        rHash: Uint8Array | string,
-        paymentRequest: string,
-        addIndex: number,
-    }
+  export type AsObject = {
+    rHash: Uint8Array | string,
+    paymentRequest: string,
+    addIndex: number,
+  }
 }
 
-export class PaymentHash extends jspb.Message { 
-    getRHashStr(): string;
-    setRHashStr(value: string): void;
+export class PaymentHash extends jspb.Message {
+  getRHashStr(): string;
+  setRHashStr(value: string): void;
 
-    getRHash(): Uint8Array | string;
-    getRHash_asU8(): Uint8Array;
-    getRHash_asB64(): string;
-    setRHash(value: Uint8Array | string): void;
+  getRHash(): Uint8Array | string;
+  getRHash_asU8(): Uint8Array;
+  getRHash_asB64(): string;
+  setRHash(value: Uint8Array | string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PaymentHash.AsObject;
-    static toObject(includeInstance: boolean, msg: PaymentHash): PaymentHash.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PaymentHash, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PaymentHash;
-    static deserializeBinaryFromReader(message: PaymentHash, reader: jspb.BinaryReader): PaymentHash;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PaymentHash.AsObject;
+  static toObject(includeInstance: boolean, msg: PaymentHash): PaymentHash.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PaymentHash, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PaymentHash;
+  static deserializeBinaryFromReader(message: PaymentHash, reader: jspb.BinaryReader): PaymentHash;
 }
 
 export namespace PaymentHash {
-    export type AsObject = {
-        rHashStr: string,
-        rHash: Uint8Array | string,
-    }
+  export type AsObject = {
+    rHashStr: string,
+    rHash: Uint8Array | string,
+  }
 }
 
-export class ListInvoiceRequest extends jspb.Message { 
-    getPendingOnly(): boolean;
-    setPendingOnly(value: boolean): void;
+export class ListInvoiceRequest extends jspb.Message {
+  getPendingOnly(): boolean;
+  setPendingOnly(value: boolean): void;
 
-    getIndexOffset(): number;
-    setIndexOffset(value: number): void;
+  getIndexOffset(): number;
+  setIndexOffset(value: number): void;
 
-    getNumMaxInvoices(): number;
-    setNumMaxInvoices(value: number): void;
+  getNumMaxInvoices(): number;
+  setNumMaxInvoices(value: number): void;
 
-    getReversed(): boolean;
-    setReversed(value: boolean): void;
+  getReversed(): boolean;
+  setReversed(value: boolean): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListInvoiceRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListInvoiceRequest): ListInvoiceRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListInvoiceRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListInvoiceRequest;
-    static deserializeBinaryFromReader(message: ListInvoiceRequest, reader: jspb.BinaryReader): ListInvoiceRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListInvoiceRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListInvoiceRequest): ListInvoiceRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListInvoiceRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListInvoiceRequest;
+  static deserializeBinaryFromReader(message: ListInvoiceRequest, reader: jspb.BinaryReader): ListInvoiceRequest;
 }
 
 export namespace ListInvoiceRequest {
-    export type AsObject = {
-        pendingOnly: boolean,
-        indexOffset: number,
-        numMaxInvoices: number,
-        reversed: boolean,
-    }
+  export type AsObject = {
+    pendingOnly: boolean,
+    indexOffset: number,
+    numMaxInvoices: number,
+    reversed: boolean,
+  }
 }
 
-export class ListInvoiceResponse extends jspb.Message { 
-    clearInvoicesList(): void;
-    getInvoicesList(): Array<Invoice>;
-    setInvoicesList(value: Array<Invoice>): void;
-    addInvoices(value?: Invoice, index?: number): Invoice;
+export class ListInvoiceResponse extends jspb.Message {
+  clearInvoicesList(): void;
+  getInvoicesList(): Array<Invoice>;
+  setInvoicesList(value: Array<Invoice>): void;
+  addInvoices(value?: Invoice, index?: number): Invoice;
 
-    getLastIndexOffset(): number;
-    setLastIndexOffset(value: number): void;
+  getLastIndexOffset(): number;
+  setLastIndexOffset(value: number): void;
 
-    getFirstIndexOffset(): number;
-    setFirstIndexOffset(value: number): void;
+  getFirstIndexOffset(): number;
+  setFirstIndexOffset(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListInvoiceResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListInvoiceResponse): ListInvoiceResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListInvoiceResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListInvoiceResponse;
-    static deserializeBinaryFromReader(message: ListInvoiceResponse, reader: jspb.BinaryReader): ListInvoiceResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListInvoiceResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListInvoiceResponse): ListInvoiceResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListInvoiceResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListInvoiceResponse;
+  static deserializeBinaryFromReader(message: ListInvoiceResponse, reader: jspb.BinaryReader): ListInvoiceResponse;
 }
 
 export namespace ListInvoiceResponse {
-    export type AsObject = {
-        invoicesList: Array<Invoice.AsObject>,
-        lastIndexOffset: number,
-        firstIndexOffset: number,
-    }
+  export type AsObject = {
+    invoicesList: Array<Invoice.AsObject>,
+    lastIndexOffset: number,
+    firstIndexOffset: number,
+  }
 }
 
-export class InvoiceSubscription extends jspb.Message { 
-    getAddIndex(): number;
-    setAddIndex(value: number): void;
+export class InvoiceSubscription extends jspb.Message {
+  getAddIndex(): number;
+  setAddIndex(value: number): void;
 
-    getSettleIndex(): number;
-    setSettleIndex(value: number): void;
+  getSettleIndex(): number;
+  setSettleIndex(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): InvoiceSubscription.AsObject;
-    static toObject(includeInstance: boolean, msg: InvoiceSubscription): InvoiceSubscription.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: InvoiceSubscription, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): InvoiceSubscription;
-    static deserializeBinaryFromReader(message: InvoiceSubscription, reader: jspb.BinaryReader): InvoiceSubscription;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): InvoiceSubscription.AsObject;
+  static toObject(includeInstance: boolean, msg: InvoiceSubscription): InvoiceSubscription.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: InvoiceSubscription, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): InvoiceSubscription;
+  static deserializeBinaryFromReader(message: InvoiceSubscription, reader: jspb.BinaryReader): InvoiceSubscription;
 }
 
 export namespace InvoiceSubscription {
-    export type AsObject = {
-        addIndex: number,
-        settleIndex: number,
-    }
+  export type AsObject = {
+    addIndex: number,
+    settleIndex: number,
+  }
 }
 
-export class Payment extends jspb.Message { 
-    getPaymentHash(): string;
-    setPaymentHash(value: string): void;
+export class Payment extends jspb.Message {
+  getPaymentHash(): string;
+  setPaymentHash(value: string): void;
 
-    getValue(): number;
-    setValue(value: number): void;
+  getValue(): number;
+  setValue(value: number): void;
 
-    getCreationDate(): number;
-    setCreationDate(value: number): void;
+  getCreationDate(): number;
+  setCreationDate(value: number): void;
 
-    clearPathList(): void;
-    getPathList(): Array<string>;
-    setPathList(value: Array<string>): void;
-    addPath(value: string, index?: number): string;
+  clearPathList(): void;
+  getPathList(): Array<string>;
+  setPathList(value: Array<string>): void;
+  addPath(value: string, index?: number): string;
 
-    getFee(): number;
-    setFee(value: number): void;
+  getFee(): number;
+  setFee(value: number): void;
 
-    getPaymentPreimage(): string;
-    setPaymentPreimage(value: string): void;
+  getPaymentPreimage(): string;
+  setPaymentPreimage(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): Payment.AsObject;
-    static toObject(includeInstance: boolean, msg: Payment): Payment.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: Payment, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): Payment;
-    static deserializeBinaryFromReader(message: Payment, reader: jspb.BinaryReader): Payment;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): Payment.AsObject;
+  static toObject(includeInstance: boolean, msg: Payment): Payment.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: Payment, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): Payment;
+  static deserializeBinaryFromReader(message: Payment, reader: jspb.BinaryReader): Payment;
 }
 
 export namespace Payment {
-    export type AsObject = {
-        paymentHash: string,
-        value: number,
-        creationDate: number,
-        pathList: Array<string>,
-        fee: number,
-        paymentPreimage: string,
-    }
+  export type AsObject = {
+    paymentHash: string,
+    value: number,
+    creationDate: number,
+    pathList: Array<string>,
+    fee: number,
+    paymentPreimage: string,
+  }
 }
 
-export class ListPaymentsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPaymentsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPaymentsRequest): ListPaymentsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPaymentsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPaymentsRequest;
-    static deserializeBinaryFromReader(message: ListPaymentsRequest, reader: jspb.BinaryReader): ListPaymentsRequest;
+export class ListPaymentsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPaymentsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPaymentsRequest): ListPaymentsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPaymentsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPaymentsRequest;
+  static deserializeBinaryFromReader(message: ListPaymentsRequest, reader: jspb.BinaryReader): ListPaymentsRequest;
 }
 
 export namespace ListPaymentsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ListPaymentsResponse extends jspb.Message { 
-    clearPaymentsList(): void;
-    getPaymentsList(): Array<Payment>;
-    setPaymentsList(value: Array<Payment>): void;
-    addPayments(value?: Payment, index?: number): Payment;
+export class ListPaymentsResponse extends jspb.Message {
+  clearPaymentsList(): void;
+  getPaymentsList(): Array<Payment>;
+  setPaymentsList(value: Array<Payment>): void;
+  addPayments(value?: Payment, index?: number): Payment;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ListPaymentsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ListPaymentsResponse): ListPaymentsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ListPaymentsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ListPaymentsResponse;
-    static deserializeBinaryFromReader(message: ListPaymentsResponse, reader: jspb.BinaryReader): ListPaymentsResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ListPaymentsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ListPaymentsResponse): ListPaymentsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ListPaymentsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ListPaymentsResponse;
+  static deserializeBinaryFromReader(message: ListPaymentsResponse, reader: jspb.BinaryReader): ListPaymentsResponse;
 }
 
 export namespace ListPaymentsResponse {
-    export type AsObject = {
-        paymentsList: Array<Payment.AsObject>,
-    }
+  export type AsObject = {
+    paymentsList: Array<Payment.AsObject>,
+  }
 }
 
-export class DeleteAllPaymentsRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DeleteAllPaymentsRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: DeleteAllPaymentsRequest): DeleteAllPaymentsRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DeleteAllPaymentsRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DeleteAllPaymentsRequest;
-    static deserializeBinaryFromReader(message: DeleteAllPaymentsRequest, reader: jspb.BinaryReader): DeleteAllPaymentsRequest;
+export class DeleteAllPaymentsRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DeleteAllPaymentsRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: DeleteAllPaymentsRequest): DeleteAllPaymentsRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DeleteAllPaymentsRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DeleteAllPaymentsRequest;
+  static deserializeBinaryFromReader(message: DeleteAllPaymentsRequest, reader: jspb.BinaryReader): DeleteAllPaymentsRequest;
 }
 
 export namespace DeleteAllPaymentsRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class DeleteAllPaymentsResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DeleteAllPaymentsResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: DeleteAllPaymentsResponse): DeleteAllPaymentsResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DeleteAllPaymentsResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DeleteAllPaymentsResponse;
-    static deserializeBinaryFromReader(message: DeleteAllPaymentsResponse, reader: jspb.BinaryReader): DeleteAllPaymentsResponse;
+export class DeleteAllPaymentsResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DeleteAllPaymentsResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: DeleteAllPaymentsResponse): DeleteAllPaymentsResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DeleteAllPaymentsResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DeleteAllPaymentsResponse;
+  static deserializeBinaryFromReader(message: DeleteAllPaymentsResponse, reader: jspb.BinaryReader): DeleteAllPaymentsResponse;
 }
 
 export namespace DeleteAllPaymentsResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class DebugLevelRequest extends jspb.Message { 
-    getShow(): boolean;
-    setShow(value: boolean): void;
+export class DebugLevelRequest extends jspb.Message {
+  getShow(): boolean;
+  setShow(value: boolean): void;
 
-    getLevelSpec(): string;
-    setLevelSpec(value: string): void;
+  getLevelSpec(): string;
+  setLevelSpec(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DebugLevelRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: DebugLevelRequest): DebugLevelRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DebugLevelRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DebugLevelRequest;
-    static deserializeBinaryFromReader(message: DebugLevelRequest, reader: jspb.BinaryReader): DebugLevelRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DebugLevelRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: DebugLevelRequest): DebugLevelRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DebugLevelRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DebugLevelRequest;
+  static deserializeBinaryFromReader(message: DebugLevelRequest, reader: jspb.BinaryReader): DebugLevelRequest;
 }
 
 export namespace DebugLevelRequest {
-    export type AsObject = {
-        show: boolean,
-        levelSpec: string,
-    }
+  export type AsObject = {
+    show: boolean,
+    levelSpec: string,
+  }
 }
 
-export class DebugLevelResponse extends jspb.Message { 
-    getSubSystems(): string;
-    setSubSystems(value: string): void;
+export class DebugLevelResponse extends jspb.Message {
+  getSubSystems(): string;
+  setSubSystems(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): DebugLevelResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: DebugLevelResponse): DebugLevelResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: DebugLevelResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): DebugLevelResponse;
-    static deserializeBinaryFromReader(message: DebugLevelResponse, reader: jspb.BinaryReader): DebugLevelResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): DebugLevelResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: DebugLevelResponse): DebugLevelResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: DebugLevelResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): DebugLevelResponse;
+  static deserializeBinaryFromReader(message: DebugLevelResponse, reader: jspb.BinaryReader): DebugLevelResponse;
 }
 
 export namespace DebugLevelResponse {
-    export type AsObject = {
-        subSystems: string,
-    }
+  export type AsObject = {
+    subSystems: string,
+  }
 }
 
-export class PayReqString extends jspb.Message { 
-    getPayReq(): string;
-    setPayReq(value: string): void;
+export class PayReqString extends jspb.Message {
+  getPayReq(): string;
+  setPayReq(value: string): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PayReqString.AsObject;
-    static toObject(includeInstance: boolean, msg: PayReqString): PayReqString.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PayReqString, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PayReqString;
-    static deserializeBinaryFromReader(message: PayReqString, reader: jspb.BinaryReader): PayReqString;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PayReqString.AsObject;
+  static toObject(includeInstance: boolean, msg: PayReqString): PayReqString.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PayReqString, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PayReqString;
+  static deserializeBinaryFromReader(message: PayReqString, reader: jspb.BinaryReader): PayReqString;
 }
 
 export namespace PayReqString {
-    export type AsObject = {
-        payReq: string,
-    }
+  export type AsObject = {
+    payReq: string,
+  }
 }
 
-export class PayReq extends jspb.Message { 
-    getDestination(): string;
-    setDestination(value: string): void;
+export class PayReq extends jspb.Message {
+  getDestination(): string;
+  setDestination(value: string): void;
 
-    getPaymentHash(): string;
-    setPaymentHash(value: string): void;
+  getPaymentHash(): string;
+  setPaymentHash(value: string): void;
 
-    getNumSatoshis(): number;
-    setNumSatoshis(value: number): void;
+  getNumSatoshis(): number;
+  setNumSatoshis(value: number): void;
 
-    getTimestamp(): number;
-    setTimestamp(value: number): void;
+  getTimestamp(): number;
+  setTimestamp(value: number): void;
 
-    getExpiry(): number;
-    setExpiry(value: number): void;
+  getExpiry(): number;
+  setExpiry(value: number): void;
 
-    getDescription(): string;
-    setDescription(value: string): void;
+  getDescription(): string;
+  setDescription(value: string): void;
 
-    getDescriptionHash(): string;
-    setDescriptionHash(value: string): void;
+  getDescriptionHash(): string;
+  setDescriptionHash(value: string): void;
 
-    getFallbackAddr(): string;
-    setFallbackAddr(value: string): void;
+  getFallbackAddr(): string;
+  setFallbackAddr(value: string): void;
 
-    getCltvExpiry(): number;
-    setCltvExpiry(value: number): void;
+  getCltvExpiry(): number;
+  setCltvExpiry(value: number): void;
 
-    clearRouteHintsList(): void;
-    getRouteHintsList(): Array<RouteHint>;
-    setRouteHintsList(value: Array<RouteHint>): void;
-    addRouteHints(value?: RouteHint, index?: number): RouteHint;
+  clearRouteHintsList(): void;
+  getRouteHintsList(): Array<RouteHint>;
+  setRouteHintsList(value: Array<RouteHint>): void;
+  addRouteHints(value?: RouteHint, index?: number): RouteHint;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PayReq.AsObject;
-    static toObject(includeInstance: boolean, msg: PayReq): PayReq.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PayReq, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PayReq;
-    static deserializeBinaryFromReader(message: PayReq, reader: jspb.BinaryReader): PayReq;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PayReq.AsObject;
+  static toObject(includeInstance: boolean, msg: PayReq): PayReq.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PayReq, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PayReq;
+  static deserializeBinaryFromReader(message: PayReq, reader: jspb.BinaryReader): PayReq;
 }
 
 export namespace PayReq {
-    export type AsObject = {
-        destination: string,
-        paymentHash: string,
-        numSatoshis: number,
-        timestamp: number,
-        expiry: number,
-        description: string,
-        descriptionHash: string,
-        fallbackAddr: string,
-        cltvExpiry: number,
-        routeHintsList: Array<RouteHint.AsObject>,
-    }
+  export type AsObject = {
+    destination: string,
+    paymentHash: string,
+    numSatoshis: number,
+    timestamp: number,
+    expiry: number,
+    description: string,
+    descriptionHash: string,
+    fallbackAddr: string,
+    cltvExpiry: number,
+    routeHintsList: Array<RouteHint.AsObject>,
+  }
 }
 
-export class FeeReportRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FeeReportRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: FeeReportRequest): FeeReportRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FeeReportRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FeeReportRequest;
-    static deserializeBinaryFromReader(message: FeeReportRequest, reader: jspb.BinaryReader): FeeReportRequest;
+export class FeeReportRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FeeReportRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: FeeReportRequest): FeeReportRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FeeReportRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FeeReportRequest;
+  static deserializeBinaryFromReader(message: FeeReportRequest, reader: jspb.BinaryReader): FeeReportRequest;
 }
 
 export namespace FeeReportRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ChannelFeeReport extends jspb.Message { 
-    getChanPoint(): string;
-    setChanPoint(value: string): void;
+export class ChannelFeeReport extends jspb.Message {
+  getChanPoint(): string;
+  setChanPoint(value: string): void;
 
-    getBaseFeeMsat(): number;
-    setBaseFeeMsat(value: number): void;
+  getBaseFeeMsat(): number;
+  setBaseFeeMsat(value: number): void;
 
-    getFeePerMil(): number;
-    setFeePerMil(value: number): void;
+  getFeePerMil(): number;
+  setFeePerMil(value: number): void;
 
-    getFeeRate(): number;
-    setFeeRate(value: number): void;
+  getFeeRate(): number;
+  setFeeRate(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ChannelFeeReport.AsObject;
-    static toObject(includeInstance: boolean, msg: ChannelFeeReport): ChannelFeeReport.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ChannelFeeReport, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ChannelFeeReport;
-    static deserializeBinaryFromReader(message: ChannelFeeReport, reader: jspb.BinaryReader): ChannelFeeReport;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ChannelFeeReport.AsObject;
+  static toObject(includeInstance: boolean, msg: ChannelFeeReport): ChannelFeeReport.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ChannelFeeReport, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ChannelFeeReport;
+  static deserializeBinaryFromReader(message: ChannelFeeReport, reader: jspb.BinaryReader): ChannelFeeReport;
 }
 
 export namespace ChannelFeeReport {
-    export type AsObject = {
-        chanPoint: string,
-        baseFeeMsat: number,
-        feePerMil: number,
-        feeRate: number,
-    }
+  export type AsObject = {
+    chanPoint: string,
+    baseFeeMsat: number,
+    feePerMil: number,
+    feeRate: number,
+  }
 }
 
-export class FeeReportResponse extends jspb.Message { 
-    clearChannelFeesList(): void;
-    getChannelFeesList(): Array<ChannelFeeReport>;
-    setChannelFeesList(value: Array<ChannelFeeReport>): void;
-    addChannelFees(value?: ChannelFeeReport, index?: number): ChannelFeeReport;
+export class FeeReportResponse extends jspb.Message {
+  clearChannelFeesList(): void;
+  getChannelFeesList(): Array<ChannelFeeReport>;
+  setChannelFeesList(value: Array<ChannelFeeReport>): void;
+  addChannelFees(value?: ChannelFeeReport, index?: number): ChannelFeeReport;
 
-    getDayFeeSum(): number;
-    setDayFeeSum(value: number): void;
+  getDayFeeSum(): number;
+  setDayFeeSum(value: number): void;
 
-    getWeekFeeSum(): number;
-    setWeekFeeSum(value: number): void;
+  getWeekFeeSum(): number;
+  setWeekFeeSum(value: number): void;
 
-    getMonthFeeSum(): number;
-    setMonthFeeSum(value: number): void;
+  getMonthFeeSum(): number;
+  setMonthFeeSum(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): FeeReportResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: FeeReportResponse): FeeReportResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: FeeReportResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): FeeReportResponse;
-    static deserializeBinaryFromReader(message: FeeReportResponse, reader: jspb.BinaryReader): FeeReportResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): FeeReportResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: FeeReportResponse): FeeReportResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: FeeReportResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): FeeReportResponse;
+  static deserializeBinaryFromReader(message: FeeReportResponse, reader: jspb.BinaryReader): FeeReportResponse;
 }
 
 export namespace FeeReportResponse {
-    export type AsObject = {
-        channelFeesList: Array<ChannelFeeReport.AsObject>,
-        dayFeeSum: number,
-        weekFeeSum: number,
-        monthFeeSum: number,
-    }
+  export type AsObject = {
+    channelFeesList: Array<ChannelFeeReport.AsObject>,
+    dayFeeSum: number,
+    weekFeeSum: number,
+    monthFeeSum: number,
+  }
 }
 
-export class PolicyUpdateRequest extends jspb.Message { 
+export class PolicyUpdateRequest extends jspb.Message {
+  hasGlobal(): boolean;
+  clearGlobal(): void;
+  getGlobal(): boolean;
+  setGlobal(value: boolean): void;
 
-    hasGlobal(): boolean;
-    clearGlobal(): void;
-    getGlobal(): boolean;
-    setGlobal(value: boolean): void;
+  hasChanPoint(): boolean;
+  clearChanPoint(): void;
+  getChanPoint(): ChannelPoint | undefined;
+  setChanPoint(value?: ChannelPoint): void;
 
+  getBaseFeeMsat(): number;
+  setBaseFeeMsat(value: number): void;
 
-    hasChanPoint(): boolean;
-    clearChanPoint(): void;
-    getChanPoint(): ChannelPoint | undefined;
-    setChanPoint(value?: ChannelPoint): void;
+  getFeeRate(): number;
+  setFeeRate(value: number): void;
 
-    getBaseFeeMsat(): number;
-    setBaseFeeMsat(value: number): void;
+  getTimeLockDelta(): number;
+  setTimeLockDelta(value: number): void;
 
-    getFeeRate(): number;
-    setFeeRate(value: number): void;
-
-    getTimeLockDelta(): number;
-    setTimeLockDelta(value: number): void;
-
-
-    getScopeCase(): PolicyUpdateRequest.ScopeCase;
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PolicyUpdateRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: PolicyUpdateRequest): PolicyUpdateRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PolicyUpdateRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PolicyUpdateRequest;
-    static deserializeBinaryFromReader(message: PolicyUpdateRequest, reader: jspb.BinaryReader): PolicyUpdateRequest;
+  getScopeCase(): PolicyUpdateRequest.ScopeCase;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PolicyUpdateRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: PolicyUpdateRequest): PolicyUpdateRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PolicyUpdateRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PolicyUpdateRequest;
+  static deserializeBinaryFromReader(message: PolicyUpdateRequest, reader: jspb.BinaryReader): PolicyUpdateRequest;
 }
 
 export namespace PolicyUpdateRequest {
-    export type AsObject = {
-        global: boolean,
-        chanPoint?: ChannelPoint.AsObject,
-        baseFeeMsat: number,
-        feeRate: number,
-        timeLockDelta: number,
-    }
+  export type AsObject = {
+    global: boolean,
+    chanPoint?: ChannelPoint.AsObject,
+    baseFeeMsat: number,
+    feeRate: number,
+    timeLockDelta: number,
+  }
 
-    export enum ScopeCase {
-        SCOPE_NOT_SET = 0,
-    
+  export enum ScopeCase {
+    SCOPE_NOT_SET = 0,
     GLOBAL = 1,
-
     CHAN_POINT = 2,
-
-    }
-
+  }
 }
 
-export class PolicyUpdateResponse extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): PolicyUpdateResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: PolicyUpdateResponse): PolicyUpdateResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: PolicyUpdateResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): PolicyUpdateResponse;
-    static deserializeBinaryFromReader(message: PolicyUpdateResponse, reader: jspb.BinaryReader): PolicyUpdateResponse;
+export class PolicyUpdateResponse extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): PolicyUpdateResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: PolicyUpdateResponse): PolicyUpdateResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: PolicyUpdateResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): PolicyUpdateResponse;
+  static deserializeBinaryFromReader(message: PolicyUpdateResponse, reader: jspb.BinaryReader): PolicyUpdateResponse;
 }
 
 export namespace PolicyUpdateResponse {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class ForwardingHistoryRequest extends jspb.Message { 
-    getStartTime(): number;
-    setStartTime(value: number): void;
+export class ForwardingHistoryRequest extends jspb.Message {
+  getStartTime(): number;
+  setStartTime(value: number): void;
 
-    getEndTime(): number;
-    setEndTime(value: number): void;
+  getEndTime(): number;
+  setEndTime(value: number): void;
 
-    getIndexOffset(): number;
-    setIndexOffset(value: number): void;
+  getIndexOffset(): number;
+  setIndexOffset(value: number): void;
 
-    getNumMaxEvents(): number;
-    setNumMaxEvents(value: number): void;
+  getNumMaxEvents(): number;
+  setNumMaxEvents(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ForwardingHistoryRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: ForwardingHistoryRequest): ForwardingHistoryRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ForwardingHistoryRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ForwardingHistoryRequest;
-    static deserializeBinaryFromReader(message: ForwardingHistoryRequest, reader: jspb.BinaryReader): ForwardingHistoryRequest;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ForwardingHistoryRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: ForwardingHistoryRequest): ForwardingHistoryRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ForwardingHistoryRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ForwardingHistoryRequest;
+  static deserializeBinaryFromReader(message: ForwardingHistoryRequest, reader: jspb.BinaryReader): ForwardingHistoryRequest;
 }
 
 export namespace ForwardingHistoryRequest {
-    export type AsObject = {
-        startTime: number,
-        endTime: number,
-        indexOffset: number,
-        numMaxEvents: number,
-    }
+  export type AsObject = {
+    startTime: number,
+    endTime: number,
+    indexOffset: number,
+    numMaxEvents: number,
+  }
 }
 
-export class ForwardingEvent extends jspb.Message { 
-    getTimestamp(): number;
-    setTimestamp(value: number): void;
+export class ForwardingEvent extends jspb.Message {
+  getTimestamp(): number;
+  setTimestamp(value: number): void;
 
-    getChanIdIn(): number;
-    setChanIdIn(value: number): void;
+  getChanIdIn(): number;
+  setChanIdIn(value: number): void;
 
-    getChanIdOut(): number;
-    setChanIdOut(value: number): void;
+  getChanIdOut(): number;
+  setChanIdOut(value: number): void;
 
-    getAmtIn(): number;
-    setAmtIn(value: number): void;
+  getAmtIn(): number;
+  setAmtIn(value: number): void;
 
-    getAmtOut(): number;
-    setAmtOut(value: number): void;
+  getAmtOut(): number;
+  setAmtOut(value: number): void;
 
-    getFee(): number;
-    setFee(value: number): void;
+  getFee(): number;
+  setFee(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ForwardingEvent.AsObject;
-    static toObject(includeInstance: boolean, msg: ForwardingEvent): ForwardingEvent.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ForwardingEvent, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ForwardingEvent;
-    static deserializeBinaryFromReader(message: ForwardingEvent, reader: jspb.BinaryReader): ForwardingEvent;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ForwardingEvent.AsObject;
+  static toObject(includeInstance: boolean, msg: ForwardingEvent): ForwardingEvent.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ForwardingEvent, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ForwardingEvent;
+  static deserializeBinaryFromReader(message: ForwardingEvent, reader: jspb.BinaryReader): ForwardingEvent;
 }
 
 export namespace ForwardingEvent {
-    export type AsObject = {
-        timestamp: number,
-        chanIdIn: number,
-        chanIdOut: number,
-        amtIn: number,
-        amtOut: number,
-        fee: number,
-    }
+  export type AsObject = {
+    timestamp: number,
+    chanIdIn: number,
+    chanIdOut: number,
+    amtIn: number,
+    amtOut: number,
+    fee: number,
+  }
 }
 
-export class ForwardingHistoryResponse extends jspb.Message { 
-    clearForwardingEventsList(): void;
-    getForwardingEventsList(): Array<ForwardingEvent>;
-    setForwardingEventsList(value: Array<ForwardingEvent>): void;
-    addForwardingEvents(value?: ForwardingEvent, index?: number): ForwardingEvent;
+export class ForwardingHistoryResponse extends jspb.Message {
+  clearForwardingEventsList(): void;
+  getForwardingEventsList(): Array<ForwardingEvent>;
+  setForwardingEventsList(value: Array<ForwardingEvent>): void;
+  addForwardingEvents(value?: ForwardingEvent, index?: number): ForwardingEvent;
 
-    getLastOffsetIndex(): number;
-    setLastOffsetIndex(value: number): void;
+  getLastOffsetIndex(): number;
+  setLastOffsetIndex(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): ForwardingHistoryResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: ForwardingHistoryResponse): ForwardingHistoryResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: ForwardingHistoryResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): ForwardingHistoryResponse;
-    static deserializeBinaryFromReader(message: ForwardingHistoryResponse, reader: jspb.BinaryReader): ForwardingHistoryResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): ForwardingHistoryResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: ForwardingHistoryResponse): ForwardingHistoryResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: ForwardingHistoryResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): ForwardingHistoryResponse;
+  static deserializeBinaryFromReader(message: ForwardingHistoryResponse, reader: jspb.BinaryReader): ForwardingHistoryResponse;
 }
 
 export namespace ForwardingHistoryResponse {
-    export type AsObject = {
-        forwardingEventsList: Array<ForwardingEvent.AsObject>,
-        lastOffsetIndex: number,
-    }
+  export type AsObject = {
+    forwardingEventsList: Array<ForwardingEvent.AsObject>,
+    lastOffsetIndex: number,
+  }
 }
+

--- a/lib/proto/wallirpc_pb.d.ts
+++ b/lib/proto/wallirpc_pb.d.ts
@@ -1,76 +1,74 @@
 // package: wallirpc
 // file: wallirpc.proto
 
-/* tslint:disable */
-
 import * as jspb from "google-protobuf";
+import * as google_api_annotations_pb from "./google/api/annotations_pb";
 
-export class GetInfoRequest extends jspb.Message { 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
-    static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
+export class GetInfoRequest extends jspb.Message {
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoRequest.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoRequest): GetInfoRequest.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoRequest, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoRequest;
+  static deserializeBinaryFromReader(message: GetInfoRequest, reader: jspb.BinaryReader): GetInfoRequest;
 }
 
 export namespace GetInfoRequest {
-    export type AsObject = {
-    }
+  export type AsObject = {
+  }
 }
 
-export class GetInfoResponse extends jspb.Message { 
-    getVersion(): number;
-    setVersion(value: number): void;
+export class GetInfoResponse extends jspb.Message {
+  getVersion(): number;
+  setVersion(value: number): void;
 
-    getProtocolversion(): number;
-    setProtocolversion(value: number): void;
+  getProtocolversion(): number;
+  setProtocolversion(value: number): void;
 
-    getBlocks(): number;
-    setBlocks(value: number): void;
+  getBlocks(): number;
+  setBlocks(value: number): void;
 
-    getTimeoffset(): number;
-    setTimeoffset(value: number): void;
+  getTimeoffset(): number;
+  setTimeoffset(value: number): void;
 
-    getConnections(): number;
-    setConnections(value: number): void;
+  getConnections(): number;
+  setConnections(value: number): void;
 
-    getProxy(): string;
-    setProxy(value: string): void;
+  getProxy(): string;
+  setProxy(value: string): void;
 
-    getDifficulty(): number;
-    setDifficulty(value: number): void;
+  getDifficulty(): number;
+  setDifficulty(value: number): void;
 
-    getTestnet(): boolean;
-    setTestnet(value: boolean): void;
+  getTestnet(): boolean;
+  setTestnet(value: boolean): void;
 
-    getRelayfee(): number;
-    setRelayfee(value: number): void;
+  getRelayfee(): number;
+  setRelayfee(value: number): void;
 
-
-    serializeBinary(): Uint8Array;
-    toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
-    static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
-    static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
-    static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
-    static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
-    static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
-    static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
+  serializeBinary(): Uint8Array;
+  toObject(includeInstance?: boolean): GetInfoResponse.AsObject;
+  static toObject(includeInstance: boolean, msg: GetInfoResponse): GetInfoResponse.AsObject;
+  static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
+  static extensionsBinary: {[key: number]: jspb.ExtensionFieldBinaryInfo<jspb.Message>};
+  static serializeBinaryToWriter(message: GetInfoResponse, writer: jspb.BinaryWriter): void;
+  static deserializeBinary(bytes: Uint8Array): GetInfoResponse;
+  static deserializeBinaryFromReader(message: GetInfoResponse, reader: jspb.BinaryReader): GetInfoResponse;
 }
 
 export namespace GetInfoResponse {
-    export type AsObject = {
-        version: number,
-        protocolversion: number,
-        blocks: number,
-        timeoffset: number,
-        connections: number,
-        proxy: string,
-        difficulty: number,
-        testnet: boolean,
-        relayfee: number,
-    }
+  export type AsObject = {
+    version: number,
+    protocolversion: number,
+    blocks: number,
+    timeoffset: number,
+    connections: number,
+    proxy: string,
+    difficulty: number,
+    testnet: boolean,
+    relayfee: number,
+  }
 }
+


### PR DESCRIPTION
There is a problem that arouses from the code generated from `.proto` files.
They contain `new Buffer()` which is deprecated in Node v10, and therefore throws an annoying warning:

`[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`

Is there a way to polyfill this? 
Or perhaps another workaround?
I was looking at [Porting to the Buffer.from()/Buffer.alloc() API](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/) this article but didn't really know the best route.