### PR TITLE
Fix Websocket connection TLS #43

### DIFF
--- a/lib/Config.ts
+++ b/lib/Config.ts
@@ -52,6 +52,7 @@ class Config {
         user: '',
         password: '',
         configPath: path.join(this.btcdDir, 'btcd.conf'),
+        certPath: path.join(this.btcdDir, 'rpc.cert'),
       },
       lnd: {
         host: '127.0.0.1',

--- a/lib/RpcClient.ts
+++ b/lib/RpcClient.ts
@@ -1,4 +1,5 @@
 import WebSocket from 'ws';
+import fs from 'fs';
 import uuidv1 from 'uuid/v1';
 import { EventEmitter } from 'events';
 
@@ -8,6 +9,7 @@ type RpcConfig = {
   port: number;
   user: string;
   password: string;
+  certPath: string;
 };
 
 /** A hack to make promises handleable from other functions */
@@ -34,11 +36,14 @@ class RpcClient extends EventEmitter {
 
   public connect = async () => {
     return new Promise((resolve, reject) => {
-      const credentials = new Buffer(`${this.config.user}:${this.config.password}`);
-      this.ws = new WebSocket(`ws://${this.config.host}:${this.config.port}/ws`, {
+      const rpcCert = fs.readFileSync(this.config.certPath,  { encoding: 'utf-8' });
+      const credentials = new Buffer.from(`${this.config.user}:${this.config.password}`);
+      this.ws = new WebSocket(`wss://${this.config.host}:${this.config.port}/ws`, {
         headers: {
           Authorization: `Basic ${credentials.toString('base64')}`,
         },
+        cert: [rpcCert],
+        ca: [rpcCert],
       });
 
       this.ws.onopen = () => {

--- a/lib/RpcClient.ts
+++ b/lib/RpcClient.ts
@@ -37,7 +37,7 @@ class RpcClient extends EventEmitter {
   public connect = async () => {
     return new Promise((resolve, reject) => {
       const rpcCert = fs.readFileSync(this.config.certPath,  { encoding: 'utf-8' });
-      const credentials = new Buffer.from(`${this.config.user}:${this.config.password}`);
+      const credentials = Buffer.from(`${this.config.user}:${this.config.password}`);
       this.ws = new WebSocket(`wss://${this.config.host}:${this.config.port}/ws`, {
         headers: {
           Authorization: `Basic ${credentials.toString('base64')}`,


### PR DESCRIPTION
Note that I made a new pr for this issue so the branch will be on `dopetard/walli-server`

There is a problem that arouses from the code generated from .proto files.
They contain new Buffer() which is deprecated in Node v10, and therefore throws an annoying warning:

[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Is there a way to polyfill this?
Or perhaps another workaround?
I was looking at Porting to the Buffer.from()/Buffer.alloc() API this article but didn't really know the best route.

Edit: Closes #43