### PR TITLE
feat: add output scripts

### DIFF
--- a/lib/Scripts.ts
+++ b/lib/Scripts.ts
@@ -1,0 +1,132 @@
+/**
+ * This file is based on scripts created by Alex Bosworth in the repository github.com/submarineswaps/swaps-service
+ */
+
+// TODO: typings for bip66 library
+import bip66 from 'bip66';
+import { script, crypto } from 'bitcoinjs-lib';
+import ops from '@michael1011/bitcoin-ops';
+import { getHexBuffer, getHexString } from './Utils';
+
+const zero = getHexBuffer('00');
+const pointSize = 32;
+
+/**
+ * DER encode bytes to eliminate sign confusion in a big-endian number
+ *
+ * @param point bytes encode
+ *
+ * @returns an enocded point buffer
+ */
+const derEncode = (point: string) => {
+  let i = 0;
+  let x = getHexBuffer(point);
+
+  while (x[i] === 0) {
+    i += 1;
+  }
+
+  if (i === x.length) {
+    return zero;
+  }
+
+  x = x.slice(i);
+
+  if (x[0] & 0x80) {
+    return Buffer.concat([zero, x], x.length + 1);
+  } else {
+    return x;
+  }
+};
+
+/**
+ * Encode a signature
+ *
+ * @param flag signature hash flag number
+ * @param signature signature hex string
+ *
+ * @returns encoded signature Buffer
+ */
+export const encodeSignature = (flag: number, signature: string) => {
+  const signatureEnd = pointSize + pointSize;
+
+  const hashType = Buffer.from([flag]);
+  const signatureBuffer = getHexBuffer(signature);
+
+  const r = derEncode(getHexString(signatureBuffer.slice(0, pointSize)));
+  const s = derEncode(getHexString(signatureBuffer.slice(pointSize, signatureEnd)));
+
+  return Buffer.concat([bip66.encode(r, s), hashType]);
+};
+
+/**
+ * Get a P2WPKH output script
+ *
+ * @param hash public key hash hex string
+ *
+ * @returns P2WPKH output script buffer
+ */
+export const p2wpkhOutput = (hash: string) => {
+  return script.compile([
+    ops.OP_0,
+    getHexBuffer(hash),
+  ]);
+};
+
+/**
+ * Encode a P2WSH output script
+ *
+ * @param scriptHex redeem script hex string
+ *
+ * @returns P2WSH output script Buffer
+ */
+export const p2wshOutput = (scriptHex: string) => {
+  return script.compile([
+    ops.OP_0,
+    crypto.sha256(getHexBuffer(scriptHex)),
+  ]);
+};
+
+/**
+ * Get a P2PKH output script
+ *
+ * @param hash public key hash hex string
+ *
+ * @returns P2PKH output script Buffer
+ */
+export const p2pkhOutput = (hash: string) => {
+  return script.compile([
+    ops.OP_DUP,
+    ops.OP_HASH160, getHexBuffer(hash),
+    ops.OP_EQUALVERIFY,
+    ops.OP_CHECKSIG,
+  ]);
+};
+
+/**
+ * Encode a P2SH output script
+ *
+ * @param scriptHex redeem script hex string
+ *
+ * @returns P2SH output script Buffer
+ */
+export const p2shOutput = (scriptHex: string) => {
+  return script.compile([
+    ops.OP_HASH160,
+    crypto.hash160(getHexBuffer(scriptHex)),
+    ops.OP_EQUAL,
+  ]);
+};
+
+/**
+ * Get a P2SH nested P2WSH output script
+ *
+ * @param scriptHex redeem script hex string
+ *
+ * @returns P2SH output script Buffer
+ */
+export const p2shP2wshOutput = (scriptHex: string) => {
+  const witness = p2wshOutput(scriptHex);
+
+  return p2shOutput(getHexString(witness));
+};

--- a/lib/Utils.ts
+++ b/lib/Utils.ts
@@ -68,6 +68,23 @@ export const resolveHome = (filename: string) => {
 };
 
 /**
+ * Get a hex encoded Buffer from a string
+ * @returns a hex encoded Buffer
+ */
+export const getHexBuffer = (input: string) => {
+  return Buffer.from(input, 'hex');
+};
+
+/**
+ * Get a hex encoded string from a Buffer
+ *
+ * @returns a hex encoded string
+ */
+export const getHexString = (input: Buffer) => {
+  return input.toString('hex');
+};
+
+/**
  * Check whether a variable is a non-array object
  */
 export const isObject = (val: any): boolean => {
@@ -77,7 +94,7 @@ export const isObject = (val: any): boolean => {
 /**
  * Get the current date in the LocaleString format.
  */
-export const getTsString = (): string => (new Date()).toLocaleString();
+export const getTsString = (): string => (new Date()).toLocaleString('en-US', { hour12: false });
 
 /**
  * Recursively merge properties from different sources into a target object, overriding any

--- a/lib/Walli.ts
+++ b/lib/Walli.ts
@@ -25,13 +25,13 @@ class Walli {
     this.config = new Config().load(config);
     this.logger = new Logger(this.config.logPath, this.config.logLevel);
 
-    if (!fs.existsSync(this.config.walletPath)) {
+    if (fs.existsSync(this.config.walletPath)) {
+      this.walletManager = new WalletManager(['BTC'], this.config.walletPath);
+    } else {
       const mnemonic = generateMnemonic();
       this.logger.warn(`generated new mnemonic: ${mnemonic}`);
 
       this.walletManager = WalletManager.fromMnemonic(mnemonic, ['BTC'], this.config.walletPath);
-    } else {
-      this.walletManager = new WalletManager(['BTC'], this.config.walletPath);
     }
 
     this.btcdClient = new BtcdClient(this.logger, this.config.btcd);

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,11 @@
         "tslib": "^1.8.1"
       }
     },
+    "@michael1011/bitcoin-ops": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@michael1011/bitcoin-ops/-/bitcoin-ops-1.4.3.tgz",
+      "integrity": "sha512-U3KPRLaIdmbfbFrMaVV/CxZl3uzqvUU3lVeh2tnfxo48iduKFtQn1g5axGD+X2LD4f+0hu0u85bLQZ0JAzS95g=="
+    },
     "@types/bip32": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/bip32/-/bip32-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "url": "git+https://github.com/dopetard/walli-server.git"
   },
   "dependencies": {
+    "@michael1011/bitcoin-ops": "^1.4.3",
     "bip32": "^1.0.2",
     "bip39": "^2.5.0",
+    "bip66": "^1.1.5",
     "bitcoin-ops": "^1.4.1",
     "bitcoinjs-lib": "^4.0.2",
     "cross-os": "^1.3.0",

--- a/test/unit/Scripts.spec.ts
+++ b/test/unit/Scripts.spec.ts
@@ -1,0 +1,104 @@
+// tslint:disable:max-line-length
+import { expect } from 'chai';
+import { Transaction } from 'bitcoinjs-lib';
+import { getHexString } from '../../lib/Utils';
+import * as scripts from '../../lib/Scripts';
+
+describe('Scripts', () => {
+  const publicKeyHash = '0000000000000000000000000000000000000000';
+  const redeemScript = '00';
+
+  it('should encode signature', () => {
+    const testData = [
+      {
+        args: {
+          flag: Transaction.SIGHASH_ALL,
+          signature: '4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09',
+        },
+        result: '304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901',
+      },
+      {
+        args: {
+          flag: Transaction.SIGHASH_ALL,
+          signature: '82235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf324bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c868724',
+        },
+        result: '304502210082235e21a2300022738dabb8e1bbd9d19cfb1e7ab8c30a23b0afbb8d178abcf3022024bf68e256c534ddfaf966bf908deb944305596f7bdcc38d69acad7f9c86872401',
+      },
+      {
+        args: {
+          flag: Transaction.SIGHASH_ALL,
+          signature: '1cadddc2838598fee7dc35a12b340c6bde8b389f7bfd19a1252a17c4b5ed2d71c1a251bbecb14b058a8bd77f65de87e51c47e95904f4c0e9d52eddc21c1415ac',
+        },
+        result: '304502201cadddc2838598fee7dc35a12b340c6bde8b389f7bfd19a1252a17c4b5ed2d71022100c1a251bbecb14b058a8bd77f65de87e51c47e95904f4c0e9d52eddc21c1415ac01',
+      },
+      {
+        args: {
+          flag: Transaction.SIGHASH_ALL,
+          signature: '1b19519b38ca1e6813cd25649ad36be8bc6a6f2ad9758089c429acd9ce0b572f3bf32193c8a3a3de1f847cd6e6eebf43c96df1ffa4d7fe920f8f71708920c65f',
+        },
+        result: '304402201b19519b38ca1e6813cd25649ad36be8bc6a6f2ad9758089c429acd9ce0b572f02203bf32193c8a3a3de1f847cd6e6eebf43c96df1ffa4d7fe920f8f71708920c65f01',
+      },
+    ];
+
+    testData.forEach((data) => {
+      const { flag, signature } = data.args;
+
+      expect(getHexString(scripts.encodeSignature(flag, signature))).to.be.equal(data.result);
+    });
+  });
+
+  it('should get P2WPKH output script', () => {
+    const testData = {
+      args: {
+        hash: publicKeyHash,
+      },
+      result: '00140000000000000000000000000000000000000000',
+    };
+
+    expect(getHexString(scripts.p2wpkhOutput(testData.args.hash))).to.be.equal(testData.result);
+  });
+
+  it('should get P2WSH output script', () => {
+    const testData = {
+      args: {
+        scriptHex: redeemScript,
+      },
+      result: '00206e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d',
+    };
+
+    expect(getHexString(scripts.p2wshOutput(testData.args.scriptHex))).to.be.equal(testData.result);
+  });
+
+  it('should get P2PKH output script', () => {
+    const testData = {
+      args: {
+        hash: publicKeyHash,
+      },
+      result: '76a914000000000000000000000000000000000000000088ac',
+    };
+
+    expect(getHexString(scripts.p2pkhOutput(testData.args.hash))).to.be.equal(testData.result);
+  });
+
+  it('should get P2SH output script', () => {
+    const testData = {
+      args: {
+        scriptHex: redeemScript,
+      },
+      result: 'a9149f7fd096d37ed2c0e3f7f0cfc924beef4ffceb6887',
+    };
+
+    expect(getHexString(scripts.p2shOutput(testData.args.scriptHex))).to.be.equal(testData.result);
+  });
+
+  it('should get P2SH nested P2WSH', () => {
+    const testData =  {
+      args: {
+        scriptHex: redeemScript,
+      },
+      result: 'a91466a823e1ae9236a70fe7321f5b26b09ec422a37787',
+    };
+
+    expect(getHexString(scripts.p2shP2wshOutput(testData.args.scriptHex))).to.be.equal(testData.result);
+  });
+});

--- a/test/unit/Utils.spec.ts
+++ b/test/unit/Utils.spec.ts
@@ -37,4 +37,11 @@ describe('Utils', () => {
       expect(result.sub[index]).to.be.equal(value);
     });
   });
+
+  it('should get a hex encoded Buffers and strings', () => {
+    const string = 'test';
+
+    expect(utils.getHexBuffer(string)).to.be.deep.equal(Buffer.from(string, 'hex'));
+    expect(utils.getHexString(Buffer.from(string))).to.be.equal(Buffer.from(string).toString('hex'));
+  });
 });


### PR DESCRIPTION
This PR adds methods to get output scripts for public keys and scripts and to encode signatures. Most of the code was originally written by Alex Bosworth and I just altered it a little bit so that it is consistent with our architecture.